### PR TITLE
abstract response type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate serde_json;
 extern crate slog_stdlog;
 extern crate slog_envlogger;
 
+use serde::Deserialize;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -31,8 +32,8 @@ use std::slice::Iter;
 //    println!("{:?}", i);
 //}
 
-impl Response {
-    pub fn hits(&self) -> &Vec<Value> {
+impl<T: Deserialize> ResponseOf<T> {
+    pub fn hits(&self) -> &Vec<T> {
         &self.hits.hits()
     }
 
@@ -42,12 +43,14 @@ impl Response {
     }
 }
 
+pub type Response = ResponseOf<Value>;
+
 #[derive(Deserialize, Debug)]
-pub struct Response {
+pub struct ResponseOf<T: Deserialize> {
     took: u64,
     timed_out: bool,
     _shards: Shards,
-    hits: Hits,
+    hits: Hits<T>,
     aggregations: Option<Aggregations>,
     status: Option<u16>
 }
@@ -219,14 +222,14 @@ struct Shards {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct Hits {
+pub struct Hits<T: Deserialize> {
     total: u64,
     max_score: u64,
-    hits: Vec<Value>
+    hits: Vec<T>
 }
 
-impl Hits {
-    pub fn hits(&self) -> &Vec<Value> {
+impl<T: Deserialize> Hits<T> {
+    pub fn hits(&self) -> &Vec<T> {
         // JPG http://stackoverflow.com/q/40006219/155423
         &self.hits
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -41,7 +41,7 @@ fn test_parse_simple_aggs() {
     let s = load_file("tests/samples/aggregation_simple.json");
     let deserialized: Response = serde_json::from_str(&s).unwrap();
 
-    assert_eq!(deserialized.aggs().unwrap().into_iter().count(), 124);
+    assert_eq!(deserialized.aggs().into_iter().count(), 124);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn test_parse_3level_aggs() {
     let s = load_file("tests/samples/aggregation_3level.json");
     let deserialized: Response = serde_json::from_str(&s).unwrap();
 
-    assert_eq!(deserialized.aggs().unwrap().into_iter().count(), 201);
+    assert_eq!(deserialized.aggs().into_iter().count(), 201);
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn test_parse_3level_multichild_aggs() {
     let max = "max_ack_pkts_sent";
     let mut first = true;
     let mut count = 0;
-    for i in deserialized.aggs().unwrap().into_iter().take(500000) {
+    for i in deserialized.aggs().into_iter().take(500000) {
         count += 1;
         if first {
             assert!(i.contains_key(min));
@@ -85,7 +85,7 @@ fn test_parse_3level_multistats_aggs() {
     let stddevu = "extstats_ack_pkts_sent_std_deviation_bounds_upper";
     let mut first = true;
     let mut count = 0;
-    for i in deserialized.aggs().unwrap().into_iter().take(500000) {
+    for i in deserialized.aggs().into_iter().take(500000) {
         count += 1;
         if first {
             assert!(i.contains_key(min));
@@ -105,7 +105,7 @@ fn test_parse_simple_aggs_no_empty_first_record() {
 
     let s = "timechart";
     let mut first = true;
-    for i in deserialized.aggs().unwrap().into_iter().take(50) {
+    for i in deserialized.aggs().into_iter().take(50) {
         if first {
             assert!(i.contains_key(s));
             first = false;


### PR DESCRIPTION
An example of #2 

This makes the hit type generic, so long as it's `Deserialize`, but keeps the public API for `Response` the same. If you know there's only going to be one type in hits then using a concrete type for `T` will be more efficient than `Value`.

I'm not really expecting this one to get merged in, if it's an idea you like then we can work out whether it's the best approach or not.