### PR TITLE
Feat/response parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>"]
 name = "elastic_responses"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,5 @@
 Copyright (c) 2017 Panoptix CC
+Copyright (c) 2017 elastic-rs Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,18 @@
 use serde::{Deserialize, Deserializer};
-use serde_json::Value;
+use serde_json::{Value, Error as JsonError};
+
+quick_error! {
+    /// An error parsing a REST API response to a success value.
+    #[derive(Debug)]
+    pub enum ResponseError {
+        Api(err: ApiError) {
+            from()
+        }
+        Json(err: JsonError) {
+            from()
+        }
+    }
+}
 
 quick_error! {
     /// A REST API error response.
@@ -60,8 +73,8 @@ impl From<Value> for ApiError {
 
         let ty = {
             let ty = obj.get("type")
-                        .and_then(|v| v.as_str())
-                        .map(|v| v.to_owned());
+                .and_then(|v| v.as_str())
+                .map(|v| v.to_owned());
 
             match ty {
                 Some(ty) => ty,

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,0 +1,49 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use parse::MaybeOkResponse;
+use super::{HttpResponse, FromResponse, ApiResult};
+
+use std::io::Read;
+
+/// Response for a get document request.
+#[derive(Deserialize, Debug)]
+pub struct GetResponseOf<T: Deserialize> {
+    #[serde(rename = "_index")]
+    pub index: String,
+    #[serde(rename = "_type")]
+    pub ty: String,
+    #[serde(rename = "_version")]
+    pub version: Option<u32>,
+    pub found: bool,
+    #[serde(rename = "_source")]
+    pub source: Option<T>,
+    #[serde(rename="_routing")]
+    pub routing: Option<String>,
+}
+
+pub type GetResponse = GetResponseOf<Value>;
+
+impl<T: Deserialize> FromResponse for GetResponseOf<T> {
+    fn from_response<I: Into<HttpResponse<R>>, R: Read>(res: I) -> ApiResult<Self> {
+        let res = res.into();
+
+        res.response(|res| {
+            match res.status() {
+                200...299 => Ok(MaybeOkResponse::new(true, res)),
+                404 => {
+                    // If we get a 404, it could be an IndexNotFound error or ok
+                    // Check if the response contains a root 'error' node
+                    let (body, res) = res.body()?;
+
+                    let is_ok = body.as_object()
+                        .and_then(|body| body.get("error"))
+                        .is_none();
+
+                    Ok(MaybeOkResponse::new(is_ok, res))
+                }
+                _ => Ok(MaybeOkResponse::new(false, res)),
+            }
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,284 +48,51 @@ extern crate serde_json;
 extern crate slog_stdlog;
 extern crate slog_envlogger;
 
-use serde::Deserialize;
-use serde_json::Value;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::slice::Iter;
-
 /// Error types from Elasticsearch
 pub mod error;
 
-// let mut i = deserialized.aggs().unwrap().into_iter();
-//
-// for x in i.by_ref().take(3) { println!("1") };
-// for x in i.take(4) { println!("2") };
-//
-// for i in deserialized.aggs().unwrap() {
-//    println!("Got record {:?}", i);
-// }
-//
-// for i in deserialized.aggs().unwrap().into_iter().take(1) {
-//    println!("{:?}", i);
-// }
+/// Response type parsing.
+pub mod parse;
 
-/// Response for a get document request.
-#[derive(Deserialize, Debug)]
-pub struct GetResponseOf<T: Deserialize> {
-    #[serde(rename = "_index")]
-    pub index: String,
-    #[serde(rename = "_type")]
-    pub ty: String,
-    #[serde(rename = "_version")]
-    pub version: Option<u32>,
-    pub found: bool,
-    #[serde(rename = "_source")]
-    pub source: Option<T>,
-    #[serde(rename="_routing")]
-    pub routing: Option<String>,
+mod get;
+mod search;
+
+pub use self::get::*;
+pub use self::search::*;
+
+use std::io::Read;
+
+use error::*;
+
+/// A raw HTTP response with enough information to parse
+/// a concrete type from it.
+pub struct HttpResponse<R> {
+    code: u16,
+    body: R,
 }
 
-pub type GetResponse = GetResponseOf<Value>;
-
-/// Main `struct` of the crate, provides access to the `hits` and `aggs` iterators.
-#[derive(Deserialize, Debug)]
-pub struct SearchResponseOf<T: Deserialize> {
-    pub took: u64,
-    pub timed_out: bool,
-    #[serde(rename = "_shards")]
-    pub shards: Shards,
-    pub hits: Hits<T>,
-    pub aggregations: Option<Aggregations>,
-    pub status: Option<u16>,
-}
-
-pub type SearchResponse = SearchResponseOf<Hit<Value>>;
-
-impl<T: Deserialize> SearchResponseOf<T> {
-    /// Returns an Iterator to the search results or hits of the response.
-    pub fn hits(&self) -> &[T] {
-        &self.hits.hits()
-    }
-
-    /// Returns an Iterator to the search results or aggregations part of the response.
-    ///
-    /// This Iterator transforms the tree-like JSON object into a row/table
-    /// based format for use with standard iterator adaptors.
-    pub fn aggs(&self) -> &Aggregations {
-        // FIXME: Create empty aggregation, remove unwrap()
-        self.aggregations.as_ref().unwrap()
-    }
-}
-
-#[derive(Deserialize, Debug)]
-pub struct Shards {
-    pub total: u32,
-    pub successful: u32,
-    pub failed: u32,
-}
-
-/// Struct to hold the search's Hits, serializable to type `T` or `serde_json::Value`
-#[derive(Deserialize, Debug)]
-pub struct Hits<T: Deserialize> {
-    pub total: u64,
-    pub max_score: u64,
-    pub hits: Vec<T>,
-}
-
-impl<T: Deserialize> Hits<T> {
-    fn hits(&self) -> &[T] {
-        &self.hits
-    }
-}
-
-#[derive(Deserialize, Debug)]
-pub struct Hit<T: Deserialize> {
-    #[serde(rename = "_index")]
-    pub index: String,
-    #[serde(rename = "_type")]
-    pub ty: String,
-    #[serde(rename = "_version")]
-    pub version: Option<u32>,
-    #[serde(rename = "_score")]
-    pub score: f32,
-    #[serde(rename = "_source")]
-    pub source: Option<T>,
-    #[serde(rename="_routing")]
-    pub routing: Option<String>,
-}
-
-/// Type Struct to hold a generic `serde_json::Value` tree of the Aggregation results.
-#[derive(Deserialize, Debug)]
-pub struct Aggregations(Value);
-
-impl<'a> IntoIterator for &'a Aggregations {
-    type Item = RowData<'a>;
-    type IntoIter = AggregationIterator<'a>;
-
-    fn into_iter(self) -> AggregationIterator<'a> {
-        AggregationIterator::new(self)
-    }
-}
-
-/// Aggregator that traverses the results from Elasticsearch's Aggregations and returns a result
-/// row by row in a table-styled fashion.
-#[derive(Debug)]
-pub struct AggregationIterator<'a> {
-    current_row: Option<RowData<'a>>,
-    current_row_finished: bool,
-    iter_stack: Vec<(Option<&'a String>, Iter<'a, Value>)>,
-    aggregations: &'a Aggregations,
-}
-
-impl<'a> AggregationIterator<'a> {
-    fn new(a: &'a Aggregations) -> AggregationIterator<'a> {
-        let o = a.0
-            .as_object()
-            .expect("Not implemented, we only cater for bucket objects");
-        // FIXME: Bad for lib // JPG: quick-error
-
-        let s = o.into_iter()
-            .filter_map(|(key, child)| {
-                child.as_object()
-                    .and_then(|child| child.get("buckets"))
-                    .and_then(Value::as_array)
-                    .map(|array| (Some(key), array.iter()))
-            })
-            .collect();
-
-        AggregationIterator {
-            current_row: None,
-            current_row_finished: false,
-            iter_stack: s,
-            aggregations: a,
+impl<R> HttpResponse<R> {
+    /// Create a new HTTP response from the given status code
+    /// and body.
+    pub fn new(status: u16, body: R) -> Self {
+        HttpResponse {
+            code: status,
+            body: body,
         }
     }
-}
 
-type Object = BTreeMap<String, Value>;
-type RowData<'a> = BTreeMap<Cow<'a, str>, &'a Value>;
-
-fn insert_value<'a>(fieldname: &str,
-                    json_object: &'a Object,
-                    keyname: &str,
-                    rowdata: &mut RowData<'a>) {
-    if let Some(v) = json_object.get(fieldname) {
-        let field_name = format!("{}_{}", keyname, fieldname);
-        debug!("ITER: Insert value! {} {:?}", field_name, v);
-        rowdata.insert(Cow::Owned(field_name), v);
+    /// Get the status code.
+    pub fn status(&self) -> u16 {
+        self.code
     }
 }
 
-impl<'a> Iterator for AggregationIterator<'a> {
-    type Item = RowData<'a>;
+type ApiResult<T> = Result<T, ResponseError>;
 
-    fn next(&mut self) -> Option<RowData<'a>> {
-        if self.current_row.is_none() {
-            // New row
-            self.current_row = Some(BTreeMap::new())
-        }
-
-        loop {
-            if let Some(mut i) = self.iter_stack.pop() {
-                let n = i.1.next();
-
-                // FIXME: can this fail?
-                let active_name = &i.0.unwrap();
-
-                // Iterate down?
-                let mut has_buckets = false;
-                // Save
-                self.iter_stack.push(i);
-
-                debug!("ITER: Depth {}", self.iter_stack.len());
-                // FIXME: Move this, to be able to process first line too
-                if let Some(n) = n {
-                    if let Some(ref mut row) = self.current_row {
-                        debug!("ITER: Row: {:?}", row);
-
-                        for (key, value) in n.as_object().expect("Shouldn't get here!") {
-                            if let Some(c) = value.as_object() {
-                                // Child Aggregation
-                                if let Some(buckets) = c.get("buckets") {
-                                    has_buckets = true;
-                                    if let Value::Array(ref a) = *buckets {
-                                        self.iter_stack.push((Some(key), a.iter()));
-                                    }
-                                    continue;
-                                }
-                                // Simple Value Aggregation Name
-                                if let Some(v) = c.get("value") {
-                                    debug!("ITER: Insert value! {} {:?}", key, v);
-                                    row.insert(Cow::Borrowed(key), v);
-                                    continue;
-                                }
-                                // Stats fields
-                                insert_value("count", c, key, row);
-                                insert_value("min", c, key, row);
-                                insert_value("max", c, key, row);
-                                insert_value("avg", c, key, row);
-                                insert_value("sum", c, key, row);
-                                insert_value("sum_of_squares", c, key, row);
-                                insert_value("variance", c, key, row);
-                                insert_value("std_deviation", c, key, row);
-
-                                if c.contains_key("std_deviation_bounds") {
-                                    if let Some(child_values) = c.get("std_deviation_bounds")
-                                        .unwrap()
-                                        .as_object() {
-                                        let u = child_values.get("upper");
-                                        let l = child_values.get("lower");
-                                        let un = format!("{}_std_deviation_bounds_upper", key);
-                                        let ln = format!("{}_std_deviation_bounds_lower", key);
-                                        debug!("ITER: Insert std_dev_bounds! {} {} u: {:?} l: \
-                                                {:?}",
-                                               un,
-                                               ln,
-                                               u.unwrap(),
-                                               l.unwrap());
-                                        row.insert(Cow::Owned(un), u.unwrap());
-                                        row.insert(Cow::Owned(ln), l.unwrap());
-                                    }
-                                }
-                            }
-
-                            if key == "key" {
-                                // Bucket Aggregation Name
-                                debug!("ITER: Insert bucket! {} {:?}", active_name, value);
-                                row.insert(Cow::Borrowed(active_name), value);
-                            } else if key == "doc_count" {
-                                // Bucket Aggregation Count
-                                debug!("ITER: Insert bucket count! {} {:?}", active_name, value);
-                                let field_name = format!("{}_doc_count", active_name);
-                                row.insert(Cow::Owned(field_name), value);
-                            }
-                        }
-                    }
-                } else {
-                    // Was nothing here, exit
-                    debug!("ITER: Exit!");
-                    self.iter_stack.pop();
-                    continue;
-                }
-
-                if !has_buckets {
-                    debug!("ITER: Bucketless!");
-                    break;
-                } else {
-                    debug!("ITER: Dive!");
-                }
-            } else {
-                debug!("ITER: Done!");
-                self.current_row = None;
-                break;
-            };
-        }
-
-        match self.current_row {
-            // FIXME: Refactor to avoid this clone()
-            Some(ref x) => Some(x.clone()),
-            None => None,
-        }
-    }
+/// Convert a response message into a either a success
+/// or failure result.
+pub trait FromResponse
+    where Self: Sized
+{
+    fn from_response<I: Into<HttpResponse<R>>, R: Read>(res: I) -> ApiResult<Self>;
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,124 @@
+use serde::Deserialize;
+use serde_json::{self, Value, Error as JsonError};
+
+use std::io::{Cursor, Read};
+
+use error::*;
+use super::{HttpResponse, ApiResult};
+
+macro_rules! read_ok {
+    ($buf:expr) => (serde_json::from_reader($buf).map_err(|e| e.into()))
+}
+
+macro_rules! read_err {
+    ($buf:expr) => ({
+        let err: ApiError = serde_json::from_reader($buf)?;
+        Err(err.into())
+    })
+}
+
+impl<R: Read> HttpResponse<R> {
+    /// Get the response body from JSON.
+    ///
+    /// This method takes a closure that determines
+    /// whether the result is successful.
+    /// If the `MaybeOkResponse` is ok, then the body will be returned as `Ok(T)`.
+    /// Otherwise the body will be returned as `Err(ApiError)`.
+    pub fn response<T, F>(self, is_ok: F) -> ApiResult<T>
+        where T: Deserialize,
+              F: Fn(UnbufferedResponse<R>) -> Result<MaybeOkResponse<R>, JsonError>
+    {
+        let maybe = is_ok(UnbufferedResponse(self))?;
+
+        match maybe.ok {
+            true => {
+                match maybe.res {
+                    MaybeBufferedResponse::Buffered(b) => read_ok!(b.0.body),
+                    MaybeBufferedResponse::Unbuffered(b) => read_ok!(b.0.body),
+                }
+            }
+            false => {
+                match maybe.res {
+                    MaybeBufferedResponse::Buffered(b) => read_err!(b.0.body),
+                    MaybeBufferedResponse::Unbuffered(b) => read_err!(b.0.body),
+                }
+            }
+        }
+    }
+}
+
+/// A response that might be successful or an `ApiError`.
+pub struct MaybeOkResponse<R> {
+    ok: bool,
+    res: MaybeBufferedResponse<R>,
+}
+
+impl<R> MaybeOkResponse<R> {
+    /// Create a new response that indicates where or not the
+    /// body is successful or an `ApiError`.
+    pub fn new<I>(ok: bool, res: I) -> Self
+        where I: Into<MaybeBufferedResponse<R>>
+    {
+        MaybeOkResponse {
+            ok: ok,
+            res: res.into(),
+        }
+    }
+}
+
+/// A response body that may or may not have been buffered.
+///
+/// This type makes it possible to inspect the response body for
+/// an error type before passing it along to be deserialised properly.
+pub enum MaybeBufferedResponse<R> {
+    Unbuffered(UnbufferedResponse<R>),
+    Buffered(BufferedResponse),
+}
+
+impl<R> From<UnbufferedResponse<R>> for MaybeBufferedResponse<R> {
+    fn from(value: UnbufferedResponse<R>) -> Self {
+        MaybeBufferedResponse::Unbuffered(value)
+    }
+}
+
+impl<R> From<BufferedResponse> for MaybeBufferedResponse<R> {
+    fn from(value: BufferedResponse) -> Self {
+        MaybeBufferedResponse::Buffered(value)
+    }
+}
+
+/// An untouched response body.
+pub struct UnbufferedResponse<R>(HttpResponse<R>);
+
+impl<R: Read> UnbufferedResponse<R> {
+    /// Get the HTTP status code for the response.
+    pub fn status(&self) -> u16 {
+        self.0.status()
+    }
+
+    /// Buffer the response body into a `serde_json::Value` and return
+    /// a `BufferedResponse`.
+    ///
+    /// This is _expensive_ so you should avoid using it if it's not
+    /// necessary.
+    pub fn body(mut self) -> Result<(Value, BufferedResponse), JsonError> {
+        let status = self.status();
+
+        let mut buf = Vec::new();
+        self.0.body.read_to_end(&mut buf)?;
+
+        let body: Value = serde_json::from_reader(Cursor::new(&buf))?;
+
+        Ok((body, BufferedResponse(HttpResponse::new(status, Cursor::new(buf)))))
+    }
+}
+
+/// A previously buffered response body.
+pub struct BufferedResponse(HttpResponse<Cursor<Vec<u8>>>);
+
+impl BufferedResponse {
+    /// Get the HTTP status code for the response.
+    pub fn status(&self) -> u16 {
+        self.0.status()
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,265 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use parse::MaybeOkResponse;
+use super::{HttpResponse, FromResponse, ApiResult};
+
+use std::io::Read;
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::slice::Iter;
+
+/// Main `struct` of the crate, provides access to the `hits` and `aggs` iterators.
+#[derive(Deserialize, Debug)]
+pub struct SearchResponseOf<T: Deserialize> {
+    pub took: u64,
+    pub timed_out: bool,
+    #[serde(rename = "_shards")]
+    pub shards: Shards,
+    pub hits: Hits<T>,
+    pub aggregations: Option<Aggregations>,
+    pub status: Option<u16>,
+}
+
+pub type SearchResponse = SearchResponseOf<Hit<Value>>;
+
+impl<T: Deserialize> FromResponse for SearchResponseOf<T> {
+    fn from_response<I: Into<HttpResponse<R>>, R: Read>(res: I) -> ApiResult<Self> {
+        let res = res.into();
+
+        res.response(|res| {
+            match res.status() {
+                200...299 => Ok(MaybeOkResponse::new(true, res)),
+                _ => Ok(MaybeOkResponse::new(false, res)),
+            }
+        })
+    }
+}
+
+impl<T: Deserialize> SearchResponseOf<T> {
+    /// Returns an Iterator to the search results or hits of the response.
+    pub fn hits(&self) -> &[T] {
+        &self.hits.hits()
+    }
+
+    /// Returns an Iterator to the search results or aggregations part of the response.
+    ///
+    /// This Iterator transforms the tree-like JSON object into a row/table
+    /// based format for use with standard iterator adaptors.
+    pub fn aggs(&self) -> &Aggregations {
+        // FIXME: Create empty aggregation, remove unwrap()
+        self.aggregations.as_ref().unwrap()
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Shards {
+    pub total: u32,
+    pub successful: u32,
+    pub failed: u32,
+}
+
+/// Struct to hold the search's Hits, serializable to type `T` or `serde_json::Value`
+#[derive(Deserialize, Debug)]
+pub struct Hits<T: Deserialize> {
+    pub total: u64,
+    pub max_score: u64,
+    pub hits: Vec<T>,
+}
+
+impl<T: Deserialize> Hits<T> {
+    fn hits(&self) -> &[T] {
+        &self.hits
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Hit<T: Deserialize> {
+    #[serde(rename = "_index")]
+    pub index: String,
+    #[serde(rename = "_type")]
+    pub ty: String,
+    #[serde(rename = "_version")]
+    pub version: Option<u32>,
+    #[serde(rename = "_score")]
+    pub score: f32,
+    #[serde(rename = "_source")]
+    pub source: Option<T>,
+    #[serde(rename="_routing")]
+    pub routing: Option<String>,
+}
+
+/// Type Struct to hold a generic `serde_json::Value` tree of the Aggregation results.
+#[derive(Deserialize, Debug)]
+pub struct Aggregations(Value);
+
+impl<'a> IntoIterator for &'a Aggregations {
+    type Item = RowData<'a>;
+    type IntoIter = AggregationIterator<'a>;
+
+    fn into_iter(self) -> AggregationIterator<'a> {
+        AggregationIterator::new(self)
+    }
+}
+
+/// Aggregator that traverses the results from Elasticsearch's Aggregations and returns a result
+/// row by row in a table-styled fashion.
+#[derive(Debug)]
+pub struct AggregationIterator<'a> {
+    current_row: Option<RowData<'a>>,
+    current_row_finished: bool,
+    iter_stack: Vec<(Option<&'a String>, Iter<'a, Value>)>,
+    aggregations: &'a Aggregations,
+}
+
+impl<'a> AggregationIterator<'a> {
+    fn new(a: &'a Aggregations) -> AggregationIterator<'a> {
+        let o = a.0
+            .as_object()
+            .expect("Not implemented, we only cater for bucket objects");
+        // FIXME: Bad for lib // JPG: quick-error
+
+        let s = o.into_iter()
+            .filter_map(|(key, child)| {
+                child.as_object()
+                    .and_then(|child| child.get("buckets"))
+                    .and_then(Value::as_array)
+                    .map(|array| (Some(key), array.iter()))
+            })
+            .collect();
+
+        AggregationIterator {
+            current_row: None,
+            current_row_finished: false,
+            iter_stack: s,
+            aggregations: a,
+        }
+    }
+}
+
+type Object = BTreeMap<String, Value>;
+type RowData<'a> = BTreeMap<Cow<'a, str>, &'a Value>;
+
+fn insert_value<'a>(fieldname: &str,
+                    json_object: &'a Object,
+                    keyname: &str,
+                    rowdata: &mut RowData<'a>) {
+    if let Some(v) = json_object.get(fieldname) {
+        let field_name = format!("{}_{}", keyname, fieldname);
+        debug!("ITER: Insert value! {} {:?}", field_name, v);
+        rowdata.insert(Cow::Owned(field_name), v);
+    }
+}
+
+impl<'a> Iterator for AggregationIterator<'a> {
+    type Item = RowData<'a>;
+
+    fn next(&mut self) -> Option<RowData<'a>> {
+        if self.current_row.is_none() {
+            // New row
+            self.current_row = Some(BTreeMap::new())
+        }
+
+        loop {
+            if let Some(mut i) = self.iter_stack.pop() {
+                let n = i.1.next();
+
+                // FIXME: can this fail?
+                let active_name = &i.0.unwrap();
+
+                // Iterate down?
+                let mut has_buckets = false;
+                // Save
+                self.iter_stack.push(i);
+
+                debug!("ITER: Depth {}", self.iter_stack.len());
+                // FIXME: Move this, to be able to process first line too
+                if let Some(n) = n {
+                    if let Some(ref mut row) = self.current_row {
+                        debug!("ITER: Row: {:?}", row);
+
+                        for (key, value) in n.as_object().expect("Shouldn't get here!") {
+                            if let Some(c) = value.as_object() {
+                                // Child Aggregation
+                                if let Some(buckets) = c.get("buckets") {
+                                    has_buckets = true;
+                                    if let Value::Array(ref a) = *buckets {
+                                        self.iter_stack.push((Some(key), a.iter()));
+                                    }
+                                    continue;
+                                }
+                                // Simple Value Aggregation Name
+                                if let Some(v) = c.get("value") {
+                                    debug!("ITER: Insert value! {} {:?}", key, v);
+                                    row.insert(Cow::Borrowed(key), v);
+                                    continue;
+                                }
+                                // Stats fields
+                                insert_value("count", c, key, row);
+                                insert_value("min", c, key, row);
+                                insert_value("max", c, key, row);
+                                insert_value("avg", c, key, row);
+                                insert_value("sum", c, key, row);
+                                insert_value("sum_of_squares", c, key, row);
+                                insert_value("variance", c, key, row);
+                                insert_value("std_deviation", c, key, row);
+
+                                if c.contains_key("std_deviation_bounds") {
+                                    if let Some(child_values) = c.get("std_deviation_bounds")
+                                        .unwrap()
+                                        .as_object() {
+                                        let u = child_values.get("upper");
+                                        let l = child_values.get("lower");
+                                        let un = format!("{}_std_deviation_bounds_upper", key);
+                                        let ln = format!("{}_std_deviation_bounds_lower", key);
+                                        debug!("ITER: Insert std_dev_bounds! {} {} u: {:?} l: \
+                                                {:?}",
+                                               un,
+                                               ln,
+                                               u.unwrap(),
+                                               l.unwrap());
+                                        row.insert(Cow::Owned(un), u.unwrap());
+                                        row.insert(Cow::Owned(ln), l.unwrap());
+                                    }
+                                }
+                            }
+
+                            if key == "key" {
+                                // Bucket Aggregation Name
+                                debug!("ITER: Insert bucket! {} {:?}", active_name, value);
+                                row.insert(Cow::Borrowed(active_name), value);
+                            } else if key == "doc_count" {
+                                // Bucket Aggregation Count
+                                debug!("ITER: Insert bucket count! {} {:?}", active_name, value);
+                                let field_name = format!("{}_doc_count", active_name);
+                                row.insert(Cow::Owned(field_name), value);
+                            }
+                        }
+                    }
+                } else {
+                    // Was nothing here, exit
+                    debug!("ITER: Exit!");
+                    self.iter_stack.pop();
+                    continue;
+                }
+
+                if !has_buckets {
+                    debug!("ITER: Bucketless!");
+                    break;
+                } else {
+                    debug!("ITER: Dive!");
+                }
+            } else {
+                debug!("ITER: Done!");
+                self.current_row = None;
+                break;
+            };
+        }
+
+        match self.current_row {
+            // FIXME: Refactor to avoid this clone()
+            Some(ref x) => Some(x.clone()),
+            None => None,
+        }
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -17,45 +17,47 @@ extern crate slog_stdlog;
 extern crate slog_envlogger;
 
 use elastic_responses::*;
-use elastic_responses::error::ApiError;
+use elastic_responses::error::*;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Cursor};
 
-fn load_file(p :&str) -> String {
+fn load_file_as_response(status: u16, p: &str) -> HttpResponse<Cursor<Vec<u8>>> {
     let mut f = File::open(p).unwrap();
-    let mut s = String::new();
-    f.read_to_string(&mut s).unwrap();
-    s
+    let mut s = Vec::new();
+    f.read_to_end(&mut s).unwrap();
+    
+    HttpResponse::new(status, Cursor::new(s))
 }
 
 #[test]
 fn test_parse_hits_simple() {
-    let s = load_file("tests/samples/hits_only.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/hits_only.json");
+
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 5);
 }
 
 #[test]
 fn test_parse_simple_aggs() {
-    let s = load_file("tests/samples/aggregation_simple.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/aggregation_simple.json");
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 124);
 }
 
 #[test]
 fn test_parse_3level_aggs() {
-    let s = load_file("tests/samples/aggregation_3level.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/aggregation_3level.json");
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 201);
 }
 
 #[test]
 fn test_parse_3level_multichild_aggs() {
-    let s = load_file("tests/samples/aggregation_3level_multichild.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/aggregation_3level_multichild.json");
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     let min = "min_ack_pkts_sent";
     let avg = "avg_ack_pkts_sent";
@@ -76,8 +78,8 @@ fn test_parse_3level_multichild_aggs() {
 
 #[test]
 fn test_parse_3level_multistats_aggs() {
-    let s = load_file("tests/samples/aggregation_3level_multistats.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/aggregation_3level_multistats.json");
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     let min = "extstats_ack_pkts_sent_min";
     let avg = "stats_ack_pkts_sent_avg";
@@ -100,8 +102,8 @@ fn test_parse_3level_multistats_aggs() {
 
 #[test]
 fn test_parse_simple_aggs_no_empty_first_record() {
-    let s = load_file("tests/samples/aggregation_simple.json");
-    let deserialized: SearchResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/aggregation_simple.json");
+    let deserialized = SearchResponse::from_response(s).unwrap();
 
     let s = "timechart";
     let mut first = true;
@@ -115,8 +117,8 @@ fn test_parse_simple_aggs_no_empty_first_record() {
 
 #[test]
 fn test_parse_found_doc_response() {
-    let s = load_file("tests/samples/get_found.json");
-    let deserialized: GetResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(200, "tests/samples/get_found.json");
+    let deserialized = GetResponse::from_response(s).unwrap();
 
     let id = deserialized.source
         .unwrap()
@@ -133,19 +135,19 @@ fn test_parse_found_doc_response() {
 
 #[test]
 fn test_parse_not_found_doc_response() {
-    let s = load_file("tests/samples/get_not_found.json");
-    let deserialized: GetResponse = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(404, "tests/samples/get_not_found.json");
+    let deserialized = GetResponse::from_response(s).unwrap();
 
     assert!(!deserialized.found);
 }
 
 #[test]
 fn test_parse_index_not_found_error() {
-    let s = load_file("tests/samples/error_index_not_found.json");
-    let deserialized: ApiError = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(404, "tests/samples/error_index_not_found.json");
+    let deserialized = GetResponse::from_response(s).unwrap_err();
 
     let valid = match deserialized {
-        ApiError::IndexNotFound { ref index }
+        ResponseError::Api(ApiError::IndexNotFound { ref index })
         if index == "carrots" => true,
         _ => false
     };
@@ -155,11 +157,11 @@ fn test_parse_index_not_found_error() {
 
 #[test]
 fn test_parse_parsing_error() {
-    let s = load_file("tests/samples/error_parsing.json");
-    let deserialized: ApiError = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(400, "tests/samples/error_parsing.json");
+    let deserialized = SearchResponse::from_response(s).unwrap_err();
 
     let valid = match deserialized {
-        ApiError::Parsing { line: 2, col: 9, ref reason } 
+        ResponseError::Api(ApiError::Parsing { line: 2, col: 9, ref reason })
         if reason == "Unknown key for a START_OBJECT in [qry]." => true,
         _ => false
     };
@@ -169,11 +171,11 @@ fn test_parse_parsing_error() {
 
 #[test]
 fn test_parse_other_error() {
-    let s = load_file("tests/samples/error_other.json");
-    let deserialized: ApiError = serde_json::from_str(&s).unwrap();
+    let s = load_file_as_response(500, "tests/samples/error_other.json");
+    let deserialized = SearchResponse::from_response(s).unwrap_err();
 
     let reason = match deserialized {
-        ApiError::Other(ref err) => err.as_object()
+        ResponseError::Api(ApiError::Other(ref err)) => err.as_object()
                                        .and_then(|err| err.get("reason"))
                                        .and_then(|reason| reason.as_str())
                                        .map(|reason| reason.to_owned()),


### PR DESCRIPTION
Closes #9 

Another fairly big API churn. This time:

- **Added elastic-rs contributors to MIT license**. I think it's a reasonable change, but am happy to discuss. I certainly don't want to give the impression that I'm downplaying your rights, which isn't the effect this change would have
- Shifted `SearchResponse` and `GetResponse` into their own modules. The `lib.rs` was getting a bit crowded. They're still exported at the root though, so it isn't a breaking change
- Added response parsing for `SearchResponse` and `GetResponse` that take the status code into account, and can optionally deserialise the response body to inspect it. The `MaybeBufferedResponse` enum makes sure if you mess with the response buffer that a complete copy is kept for other users, since that buffer is probably one-way.