### PR TITLE
Implement Read for HttpResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>"]
 name = "elastic_responses"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>"]
 name = "elastic_responses"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ pub use self::get::*;
 pub use self::search::*;
 
 use std::io::Read;
+use serde_json::Value;
+use self::parse::MaybeOkResponse;
 
 use error::*;
 
@@ -95,4 +97,17 @@ pub trait FromResponse
     where Self: Sized
 {
     fn from_response<I: Into<HttpResponse<R>>, R: Read>(res: I) -> ApiResult<Self>;
+}
+
+impl FromResponse for Value {
+    fn from_response<I: Into<HttpResponse<R>>, R: Read>(res: I) -> ApiResult<Self> {
+        let res = res.into();
+
+        res.response(|res| {
+            match res.status() {
+                200...299 => Ok(MaybeOkResponse::new(true, res)),
+                _ => Ok(MaybeOkResponse::new(false, res)),
+            }
+        })
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde_json::{self, Value, Error as JsonError};
 
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Result as IoResult};
 
 use error::*;
 use super::{HttpResponse, ApiResult};
@@ -15,6 +15,12 @@ macro_rules! read_err {
         let err: ApiError = serde_json::from_reader($buf)?;
         Err(err.into())
     })
+}
+
+impl<R: Read> Read for HttpResponse<R> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        self.body.read(buf)
+    }
 }
 
 impl<R: Read> HttpResponse<R> {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -18,6 +18,7 @@ extern crate slog_envlogger;
 
 use elastic_responses::*;
 use elastic_responses::error::*;
+use serde_json::Value;
 use std::fs::File;
 use std::io::{Read, Cursor};
 
@@ -27,6 +28,18 @@ fn load_file_as_response(status: u16, p: &str) -> HttpResponse<Cursor<Vec<u8>>> 
     f.read_to_end(&mut s).unwrap();
     
     HttpResponse::new(status, Cursor::new(s))
+}
+
+#[test]
+fn test_read_response() {
+    let mut res = HttpResponse::new(200, Cursor::new(vec![1, 2, 3]));
+
+    let mut actual = Vec::new();
+    res.read_to_end(&mut actual).unwrap();
+
+    let expected = vec![1, 2, 3];
+
+    assert_eq!(expected, actual);
 }
 
 #[test]
@@ -113,6 +126,15 @@ fn test_parse_simple_aggs_no_empty_first_record() {
             first = false;
         }
     }
+}
+
+#[test]
+fn test_parse_hits_simple_as_value() {
+    let s = load_file_as_response(200, "tests/samples/hits_only.json");
+
+    let deserialized = Value::from_response(s).unwrap();
+
+    assert_eq!(deserialized["_shards"]["total"].as_u64().unwrap(), 5);
 }
 
 #[test]


### PR DESCRIPTION
Improves some response handling ergonomics:

- Implements `Read` for a `HttpResponse` so you can buffer out the body in the same way you can with a `reqwest::Response`
- Implements `FromResponse` for `serde_json::Value` that returns `Ok(Value)` if the response status is `2xx`, or `Err(ApiError)` otherwise. I think this is a good catch-all response type for all the cases we don't support yet.