### PR TITLE
Add ok and err methods to parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>"]
 name = "elastic_responses"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # [`elastic_responses`](https://docs.rs/elastic_responses/*/elastic_responses/) [![Latest Version](https://img.shields.io/crates/v/elastic_responses.svg)](https://crates.io/crates/elastic_responses)
 
-A crate to handle parsing and handling Elasticsearch search results which provides
-convenient iterators to step through the results returned. It is designed to work
-with [`elastic-reqwest`](https://github.com/elastic-rs/elastic-reqwest/).
+A crate to handle parsing and handling Elasticsearch search results which provides convenient iterators to step through the results returned. It is designed to work with [`elastic-reqwest`](https://github.com/elastic-rs/elastic-reqwest/).
 
 ## Build Status
 Platform  | Channel | Status

--- a/src/get.rs
+++ b/src/get.rs
@@ -42,7 +42,7 @@ impl<T: Deserialize> FromResponse for GetResponseOf<T> {
 
                     Ok(MaybeOkResponse::new(is_ok, res))
                 }
-                _ => Ok(MaybeOkResponse::new(false, res)),
+                _ => Ok(MaybeOkResponse::err(res)),
             }
         })
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -64,6 +64,20 @@ impl<R> MaybeOkResponse<R> {
             res: res.into(),
         }
     }
+
+    /// Create a response where the body is successful.
+    pub fn ok<I>(res: I) -> Self
+        where I: Into<MaybeBufferedResponse<R>>
+    {
+        Self::new(true, res)
+    }
+
+    /// Create a resposne where the body is an error.
+    pub fn err<I>(res: I) -> Self
+        where I: Into<MaybeBufferedResponse<R>>
+    {
+        Self::new(false, res)
+    }
 }
 
 /// A response body that may or may not have been buffered.

--- a/src/search.rs
+++ b/src/search.rs
@@ -29,8 +29,8 @@ impl<T: Deserialize> FromResponse for SearchResponseOf<T> {
 
         res.response(|res| {
             match res.status() {
-                200...299 => Ok(MaybeOkResponse::new(true, res)),
-                _ => Ok(MaybeOkResponse::new(false, res)),
+                200...299 => Ok(MaybeOkResponse::ok(res)),
+                _ => Ok(MaybeOkResponse::err(res)),
             }
         })
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,9 +1,4 @@
-
 extern crate elastic_responses;
-
-#[macro_use]
-extern crate json_str;
-
 extern crate serde_json;
 
 use elastic_responses::*;


### PR DESCRIPTION
Closes #18 

This is a non-breaking change, it introduces two new methods to `MaybeOkResponse` that communicate the intent better. The existing tests for `SearchResponse` verify it works.