### PR TITLE
Handle situations where score may be null

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -103,7 +103,7 @@ pub struct Hit<T: Deserialize> {
     #[serde(rename = "_version")]
     pub version: Option<u32>,
     #[serde(rename = "_score")]
-    pub score: f32,
+    pub score: Option<f32>,
     #[serde(rename = "_source")]
     pub source: Option<T>,
     #[serde(rename="_routing")]

--- a/tests/samples/search_null_score.json
+++ b/tests/samples/search_null_score.json
@@ -1,0 +1,30 @@
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 6,
+    "successful": 6,
+    "failed": 0
+  },
+  "hits": {
+    "total": 65,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "someindex",
+        "_type": "sometype",
+        "_id": "AVuP5kyDpiSd7FlbjnkH",
+        "_score": null,
+        "_source": {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "timestamp": "20170421T094446.439Z"
+        },
+        "sort": [
+          1492767886439
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/mod.rs
+++ b/tests/search/mod.rs
@@ -25,6 +25,15 @@ fn success_parse_hits_simple() {
 }
 
 #[test]
+fn success_parse_hits_no_score() {
+    let s = load_file_as_response(200, "tests/samples/search_null_score.json");
+
+    let deserialized = SearchResponse::from_response(s).unwrap();
+
+    assert_eq!(deserialized.hits().into_iter().count(), 1);
+}
+
+#[test]
 fn success_parse_simple_aggs() {
     let s = load_file_as_response(200, "tests/samples/search_aggregation_simple.json");
     let deserialized = SearchResponse::from_response(s).unwrap();


### PR DESCRIPTION
When returning sorted results I came across `score:null` results, I was able to produce this by a search similar to:

```
{
  "size": 1,
  "sort": [
    {
      "timestamp": {
        "order": "desc",
        "unmapped_type": "boolean"
      }
    }
  ],
  "query": {
    "query_string": {
      "query": "*"
    }
  }
}
```

This patch allows the `score` field in the response struct to be `null`