### PR TITLE
Make max_score f32

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -78,7 +78,7 @@ impl<T> SearchResponseOf<T> {
 #[derive(Deserialize, Debug)]
 pub struct Hits<T> {
     pub total: u64,
-    pub max_score: Option<u64>,
+    pub max_score: Option<f32>,
     pub hits: Vec<T>,
 }
 

--- a/tests/samples/search_hits_only.json
+++ b/tests/samples/search_hits_only.json
@@ -8,7 +8,7 @@
   },
   "hits": {
     "total": 93315,
-    "max_score": 1,
+    "max_score": 0.688,
     "hits": [
       {
         "_index": "logstash-cee-2016.09.25",


### PR DESCRIPTION
Makes the `max_score` field a `f32`, so that non integer values will be deserialised properly.

This is _technically_ a breaking change, but I think in practice it won't impact existing code.