### PR TITLE
Refactor Parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>"]
 name = "elastic_responses"
-version = "0.7.2"
+version = "0.8.0"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Query your Elasticsearch Cluster, then iterate through the results:
 let mut res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
 
 // Parse body to JSON
-let body_as_json: SearchResponse = res.json().unwrap();
+let body_as_json = parse::<SearchResponse>().from_reader(res.status().to_u16(), res).unwrap();
 
 // Use hits() or aggs() iterators
 // Hits
@@ -55,7 +55,7 @@ Bulk response operations are split by whether they succeeded or failed:
 let mut res = client.elastic_req(&params, BulkRequest::new(body)).unwrap();
 
 // Parse body to JSON
-let body_as_json: BulkResponse = res.json().unwrap();
+let body_as_json = parse::<BulkResponse>().from_reader(res.status().to_u16(), res).unwrap();
 
 // Do something with successful operations
 for op in body_as_json.items.ok {

--- a/samples/bulk/src/main.rs
+++ b/samples/bulk/src/main.rs
@@ -9,7 +9,7 @@ extern crate elastic_responses;
 
 use elastic_reqwest::ElasticClient;
 use elastic_reqwest::req::BulkRequest;
-use elastic_responses::{HttpResponse, BulkErrorsResponse};
+use elastic_responses::{parse, BulkErrorsResponse};
 
 fn get_req() -> String {
     let mut bulk = String::new();
@@ -31,13 +31,10 @@ fn main() {
     let (client, params) = elastic_reqwest::default().unwrap();
 
     // Send the request and read the response.
-    let http_res = {
-        let res = client.elastic_req(&params, BulkRequest::new(get_req())).unwrap();
-        HttpResponse::from_read(res.status().to_u16(), res)
-    };
+    let res = client.elastic_req(&params, BulkRequest::new(get_req())).unwrap();
 
     //Parse body to JSON. You could also use `BulkErrorsResponse`.
-    let body_as_json: BulkErrorsResponse = http_res.into_response().unwrap();
+    let body_as_json: BulkErrorsResponse = parse::<BulkErrorsResponse>().from_reader(res.status().to_u16(), res).unwrap();
 
     println!("{:?}", body_as_json);
 }

--- a/samples/search/src/main.rs
+++ b/samples/search/src/main.rs
@@ -9,7 +9,7 @@ extern crate elastic_responses;
 
 use elastic_reqwest::{ElasticClient};
 use elastic_reqwest::req::SearchRequest;
-use elastic_responses::{HttpResponse, SearchResponse};
+use elastic_responses::{parse, SearchResponse};
 
 fn main() {
 
@@ -67,13 +67,10 @@ fn main() {
     });
 
     // Send the request and read the response.
-    let http_res = {
-        let res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
-        HttpResponse::from_read(res.status().to_u16(), res)
-    };
+    let res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
 
     //Parse body to JSON
-    let body_as_json: SearchResponse = http_res.into_response().unwrap();
+    let body_as_json: SearchResponse = parse::<SearchResponse>().from_reader(res.status().to_u16(), res).unwrap();
 
     //Use hits() or aggs() iterators
     //Hits

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -2,8 +2,7 @@ use serde::de::{Deserialize, Deserializer, Visitor, Error as DeError, SeqAccess,
 use serde_json::Value;
 use common::Shards;
 
-use super::HttpResponseHead;
-use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
 use std::cmp;
@@ -12,6 +11,8 @@ use std::marker::PhantomData;
 use std::error::Error;
 
 type BulkError = Value;
+
+type DefaultString = String;
 
 /// Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
 /// 
@@ -90,7 +91,7 @@ type BulkError = Value;
 /// # }
 /// ``` 
 #[derive(Deserialize, Debug, Clone)]
-pub struct BulkResponse<TIndex = String, TType = String, TId = String> {
+pub struct BulkResponse<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
     pub took: u64,
     errors: bool,
     pub items: BulkItems<TIndex, TType, TId>,
@@ -170,7 +171,7 @@ impl<TIndex, TType, TId> BulkResponse<TIndex, TType, TId> {
 /// ``` 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(bound(deserialize = "TIndex: Deserialize<'de>, TType: Deserialize<'de>, TId: Deserialize<'de>"))]
-pub struct BulkErrorsResponse<TIndex = String, TType = String, TId = String> {
+pub struct BulkErrorsResponse<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
     pub took: u64,
     errors: bool,
     #[serde(deserialize_with = "deserialize_bulk_item_errors")]
@@ -189,7 +190,7 @@ impl<TIndex, TType, TId> BulkErrorsResponse<TIndex, TType, TId> {
 
 /// A successful bulk response item.
 #[derive(Debug, Clone)]
-pub struct BulkItem<TIndex, TType, TId> {
+pub struct BulkItem<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
     pub action: BulkAction,
     pub index: TIndex,
     pub ty: TType,
@@ -202,7 +203,7 @@ pub struct BulkItem<TIndex, TType, TId> {
 
 /// A failed bulk response item.
 #[derive(Debug, Clone)]
-pub struct BulkItemError<TIndex, TType, TId> {
+pub struct BulkItemError<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
     pub action: BulkAction,
     pub index: TIndex,
     pub ty: TType,

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 
 type BulkError = Value;
 
-type DefaultString = String;
+type DefaultAllocatedField = String;
 
 /// Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
 /// 
@@ -91,7 +91,7 @@ type DefaultString = String;
 /// # }
 /// ``` 
 #[derive(Deserialize, Debug, Clone)]
-pub struct BulkResponse<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
+pub struct BulkResponse<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     pub took: u64,
     errors: bool,
     pub items: BulkItems<TIndex, TType, TId>,
@@ -171,7 +171,7 @@ impl<TIndex, TType, TId> BulkResponse<TIndex, TType, TId> {
 /// ``` 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(bound(deserialize = "TIndex: Deserialize<'de>, TType: Deserialize<'de>, TId: Deserialize<'de>"))]
-pub struct BulkErrorsResponse<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
+pub struct BulkErrorsResponse<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     pub took: u64,
     errors: bool,
     #[serde(deserialize_with = "deserialize_bulk_item_errors")]
@@ -190,7 +190,7 @@ impl<TIndex, TType, TId> BulkErrorsResponse<TIndex, TType, TId> {
 
 /// A successful bulk response item.
 #[derive(Debug, Clone)]
-pub struct BulkItem<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
+pub struct BulkItem<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     pub action: BulkAction,
     pub index: TIndex,
     pub ty: TType,
@@ -203,7 +203,7 @@ pub struct BulkItem<TIndex = DefaultString, TType = DefaultString, TId = Default
 
 /// A failed bulk response item.
 #[derive(Debug, Clone)]
-pub struct BulkItemError<TIndex = DefaultString, TType = DefaultString, TId = DefaultString> {
+pub struct BulkItemError<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     pub action: BulkAction,
     pub index: TIndex,
     pub ty: TType,

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,17 @@
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
+use error::*;
+
+/// A standard command acknowledgement response.
+#[derive(Deserialize, Debug, Clone)]
+pub struct CommandResponse {
+    pub acknowledged: bool
+}
+
+impl IsOk for CommandResponse {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead, body: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+        match head.status() {
+            200...299 => Ok(MaybeOkResponse::ok(body)),
+            _ => Ok(MaybeOkResponse::err(body)),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,10 @@ quick_error! {
             description("request parse error")
             display("request parse error: '{}' on line: {}, col: {}", reason, line, col)
         }
+        MapperParsing { reason: String } {
+            description("mapper parse error")
+            display("mapper parse error: '{}'", reason)
+        }
         ActionRequestValidation { reason: String }
         Other(v: Map<String, Value>) {
             description("error response from Elasticsearch")
@@ -108,6 +112,13 @@ impl From<Map<String, Value>> for ApiError {
                 ApiError::Parsing {
                     line: line,
                     col: col,
+                    reason: reason.into(),
+                }
+            }
+            "mapper_parsing_exception" => {
+                let reason = error_key!(obj[reason]: |v| v.as_str());
+
+                ApiError::MapperParsing {
                     reason: reason.into(),
                 }
             }

--- a/src/get.rs
+++ b/src/get.rs
@@ -12,6 +12,8 @@ pub struct GetResponseOf<T> {
     pub index: String,
     #[serde(rename = "_type")]
     pub ty: String,
+    #[serde(rename = "_id")]
+    pub id: String,
     #[serde(rename = "_version")]
     pub version: Option<u32>,
     pub found: bool,

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,8 +1,7 @@
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use super::HttpResponseHead;
-use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
 /// Response for a [get document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html).

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,5 @@
-use super::HttpResponseHead;
 use common::Shards;
-use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
 /// Response for a document index request.

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,29 @@
+use super::HttpResponseHead;
+use common::Shards;
+use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use error::*;
+
+/// Response for a document index request.
+#[derive(Deserialize, Debug)]
+pub struct IndexResponse {
+    #[serde(rename = "_index")]
+    pub index: String,
+    #[serde(rename = "_type")]
+    pub ty: String,
+    #[serde(rename = "_id")]
+    pub id: String,
+    #[serde(rename = "_version")]
+    pub version: Option<u32>,
+    pub created: bool,
+    #[serde(rename = "_shards")]
+    pub shards: Shards,
+}
+
+impl IsOk for IndexResponse {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead, body: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+        match head.status() {
+            200...299 => Ok(MaybeOkResponse::ok(body)),
+            _ => Ok(MaybeOkResponse::err(body)),
+        }
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,7 +2,7 @@ use common::Shards;
 use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
-/// Response for a document index request.
+/// Response for an [index document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
 #[derive(Deserialize, Debug)]
 pub struct IndexResponse {
     #[serde(rename = "_index")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,27 @@
 //!
 //! A crate to handle parsing and handling Elasticsearch search results which provides
 //! convenient iterators to step through the results returned. It is designed to work
-//! with [`elastic-reqwest`](https://github.com/elastic-rs/elastic-reqwest/).
+//! with [`elastic-reqwest`][elastic-reqwest].
 //! 
-//! This crate provides a generic `HttpResponse` that can be parsed into a concrete response
-//! type, or an `ApiError`.
+//! This crate provides parsers that can be used to convert a http response into a concrete
+//! type or an API error.
 //!
 //! ## Usage
+//! 
+//! This crate is on [crates.io][crates-io].
+//! Add `elastic_responses` to your `Cargo.toml`:
+//! 
+//! ```text
+//! [dependencies]
+//! elastic_responses = "*"
+//! ```
+//! 
+//! Use the [`parse`][parse] function to deserialise a http response to a `Result<T, ApiError>` for some
+//! concrete response type `T`.
+//! 
+//! # Examples
 //!
-//! Query your Elasticsearch Cluster, then iterate through the results
+//! Run a [Query DSL][query-dsl] query, then iterate through the results:
 //!
 //! ```no_run
 //! # extern crate elastic_responses;
@@ -21,7 +34,7 @@
 //! 
 //! // Parse body to JSON as an elastic_responses::SearchResponse object
 //! // If the response is an API error then it'll be parsed into a friendly Rust error
-//! let body_as_json: SearchResponse = parse().from_slice(response_status, response_body).unwrap();
+//! let body_as_json = parse::<SearchResponse>().from_slice(response_status, response_body).unwrap();
 //!
 //! // Use hits() or aggs() iterators
 //! // Hits
@@ -36,12 +49,12 @@
 //! # }
 //! ```
 //! 
-//! Any type that implements `IsOk` can be parsed into a concrete response or an `ApiError`:
+//! Run a [Get Document][get-document] request, and handle cases where the document wasn't found or the index doesn't exist:
 //! 
 //! ```no_run
 //! # extern crate serde_json;
 //! # extern crate elastic_responses;
-//! # use serde_json::*;
+//! # use serde_json::Value;
 //! # use elastic_responses::*;
 //! # use elastic_responses::error::*;
 //! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
@@ -52,11 +65,14 @@
 //! let get_response = parse::<GetResponseOf<Value>>().from_slice(response_status, response_body);
 //! 
 //! match get_response {
+//!     Ok(ref res) if res.found => {
+//!         // The document was found
+//!     }
 //!     Ok(res) => {
-//!         // Do something with the GetResponse
+//!         // The document was not found
 //!     }
 //!     Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
-//!         // Do something with the missing index error
+//!         // The index doesn't exist
 //!     }
 //!     _ => {
 //!         // Some other error
@@ -64,6 +80,11 @@
 //! }
 //! # }
 //! ```
+//! [elastic-reqwest]: https://github.com/elastic-rs/elastic-reqwest/
+//! [crates-io]: https://crates.io/crates/elastic_responses
+//! [query-dsl]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html
+//! [get-document]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
+//! [parse]: parsing/fn.parse.html
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,14 @@
 //! ```no_run
 //! # extern crate elastic_responses;
 //! # use elastic_responses::*;
-//! # fn do_request() -> HttpResponseSlice<Vec<u8>> { unimplemented!() }
+//! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
 //! # fn main() {
-//! // Send a request (omitted, see `samples/search`)
-//! let http_response = do_request();
+//! // Send a document get request and read as a response
+//! let (response_status, response_body) = do_request();
 //! 
 //! // Parse body to JSON as an elastic_responses::SearchResponse object
 //! // If the response is an API error then it'll be parsed into a friendly Rust error
-//! let body_as_json: SearchResponse = http_response.into_response().unwrap();
+//! let body_as_json: SearchResponse = parse().from_slice(response_status, response_body).unwrap();
 //!
 //! // Use hits() or aggs() iterators
 //! // Hits
@@ -35,6 +35,35 @@
 //! }
 //! # }
 //! ```
+//! 
+/// Any type that implements `IsOk` can be parsed into a concrete response or an `ApiError`:
+/// 
+/// ```no_run
+/// # extern crate serde_json;
+/// # extern crate elastic_responses;
+/// # use serde_json::*;
+/// # use elastic_responses::*;
+/// # use elastic_responses::error::*;
+/// # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+/// # fn main() {
+/// // Send a document get request and read as a response
+/// let (response_status, response_body) = do_request();
+///
+/// let get_response = parse::<GetResponseOf<Value>>().from_slice(response_status, response_body);
+/// 
+/// match get_response {
+///     Ok(res) => {
+///         // Do something with the GetResponse
+///     }
+///     Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
+///         // Do something with the missing index error
+///     }
+///     _ => {
+///         // Some other error
+///     }
+/// }
+/// # }
+/// ```
 
 #[macro_use]
 extern crate log;
@@ -52,9 +81,10 @@ extern crate slog_stdlog;
 extern crate slog_envlogger;
 
 pub mod error;
-pub mod parse;
+pub mod parsing;
 
 mod common;
+mod command;
 mod ping;
 mod get;
 mod search;
@@ -62,88 +92,11 @@ mod bulk;
 mod index;
 
 pub use self::common::*;
+pub use self::command::*;
 pub use self::ping::*;
 pub use self::get::*;
 pub use self::search::*;
 pub use self::bulk::*;
 pub use self::index::*;
 
-use std::io::{Read, Result as IoResult};
-
-/// The non-body component of the HTTP response.
-pub struct HttpResponseHead {
-    code: u16,
-}
-
-impl HttpResponseHead {
-    /// Get the status code.
-    pub fn status(&self) -> u16 {
-        self.code
-    }
-}
-
-/// A HTTP response body that implements `Read`.
-pub struct ReadBody<B>(B);
-
-/// A HTTP response body that implements `AsRef<[u8]>`
-pub struct SliceBody<B>(B);
-
-/// A raw HTTP response with enough information to parse
-/// a concrete type from it.
-/// 
-/// `HttpResponse`s are generic over the body kind, which can be either
-/// an IO buffer or contiguous slice of bytes.
-pub struct HttpResponse<B> {
-    head: HttpResponseHead,
-    body: B,
-}
-
-impl<B> HttpResponse<B> {
-    /// Create a new HTTP response from the given status code
-    /// and body.
-    fn new(status: u16, body: B) -> Self {
-        HttpResponse {
-            head: HttpResponseHead {
-                code: status,
-            },
-            body: body,
-        }
-    }
-
-    /// Get the status code.
-    pub fn status(&self) -> u16 {
-        self.head.code
-    }
-}
-
-impl<B: AsRef<[u8]>> AsRef<[u8]> for HttpResponse<SliceBody<B>> {
-    fn as_ref(&self) -> &[u8] {
-        self.body.0.as_ref()
-    }
-}
-
-impl<B: Read> Read for HttpResponse<ReadBody<B>> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        self.body.0.read(buf)
-    }
-}
-
-impl<B: AsRef<[u8]>> HttpResponse<SliceBody<B>> {
-    /// Build a HTTP response from a contiguous slice.
-    pub fn from_slice(status: u16, body: B) -> Self {
-        Self::new(status, SliceBody(body))
-    }
-}
-
-impl<B: Read> HttpResponse<ReadBody<B>> {
-    /// Build a HTTP response from a byte reader.
-    /// 
-    /// # Examples
-    /// 
-    pub fn from_read(status: u16, body: B) -> Self {
-        Self::new(status, ReadBody(body))
-    }
-}
-
-pub type HttpResponseRead<T> = HttpResponse<ReadBody<T>>;
-pub type HttpResponseSlice<T> = HttpResponse<SliceBody<T>>;
+pub use self::parsing::parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,34 +36,34 @@
 //! # }
 //! ```
 //! 
-/// Any type that implements `IsOk` can be parsed into a concrete response or an `ApiError`:
-/// 
-/// ```no_run
-/// # extern crate serde_json;
-/// # extern crate elastic_responses;
-/// # use serde_json::*;
-/// # use elastic_responses::*;
-/// # use elastic_responses::error::*;
-/// # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-/// # fn main() {
-/// // Send a document get request and read as a response
-/// let (response_status, response_body) = do_request();
-///
-/// let get_response = parse::<GetResponseOf<Value>>().from_slice(response_status, response_body);
-/// 
-/// match get_response {
-///     Ok(res) => {
-///         // Do something with the GetResponse
-///     }
-///     Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
-///         // Do something with the missing index error
-///     }
-///     _ => {
-///         // Some other error
-///     }
-/// }
-/// # }
-/// ```
+//! Any type that implements `IsOk` can be parsed into a concrete response or an `ApiError`:
+//! 
+//! ```no_run
+//! # extern crate serde_json;
+//! # extern crate elastic_responses;
+//! # use serde_json::*;
+//! # use elastic_responses::*;
+//! # use elastic_responses::error::*;
+//! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+//! # fn main() {
+//! // Send a document get request and read as a response
+//! let (response_status, response_body) = do_request();
+//!
+//! let get_response = parse::<GetResponseOf<Value>>().from_slice(response_status, response_body);
+//! 
+//! match get_response {
+//!     Ok(res) => {
+//!         // Do something with the GetResponse
+//!     }
+//!     Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
+//!         // Do something with the missing index error
+//!     }
+//!     _ => {
+//!         // Some other error
+//!     }
+//! }
+//! # }
+//! ```
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,12 +59,14 @@ mod ping;
 mod get;
 mod search;
 mod bulk;
+mod index;
 
 pub use self::common::*;
 pub use self::ping::*;
 pub use self::get::*;
 pub use self::search::*;
 pub use self::bulk::*;
+pub use self::index::*;
 
 use std::io::{Read, Result as IoResult};
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -7,6 +7,7 @@ use serde_json::{self, Value};
 
 use error::*;
 
+/// A parser that separates taking a response type from the readable body type.
 pub struct Parse<T> {
     _marker: PhantomData<T>,
 }
@@ -25,7 +26,7 @@ impl<T: IsOk + DeserializeOwned> Parse<T> {
     }
 
     /// Try parse an arbitrary reader into a concrete response.
-    pub fn from_read<B: Read, H: Into<HttpResponseHead>>(self, head: H, body: B) -> Result<T, ResponseError> {
+    pub fn from_reader<B: Read, H: Into<HttpResponseHead>>(self, head: H, body: B) -> Result<T, ResponseError> {
         from_body(head.into(), ReadBody(body))
     }
 }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,5 +1,4 @@
-use super::HttpResponseHead;
-use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
 /// Response for a cluster ping request.

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,8 +1,8 @@
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 
-use super::{Shards, HttpResponseHead};
-use parse::{IsOk, ResponseBody, Unbuffered, MaybeOkResponse};
+use common::Shards;
+use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
 use std::borrow::Cow;

--- a/tests/bulk/mod.rs
+++ b/tests/bulk/mod.rs
@@ -3,12 +3,12 @@ extern crate serde_json;
 
 use elastic_responses::*;
 use elastic_responses::error::*;
-use ::load_file_as_response;
+use ::load_file;
 
 #[test]
 fn success_parse_index_ops() {
-    let s = load_file_as_response(200, "tests/samples/bulk_index.json");
-    let deserialized = s.into_response::<BulkResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_index.json");
+    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_ok());
 
@@ -18,8 +18,8 @@ fn success_parse_index_ops() {
 
 #[test]
 fn success_parse_index_ops_errors_only() {
-    let s = load_file_as_response(200, "tests/samples/bulk_index.json");
-    let deserialized = s.into_response::<BulkErrorsResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_index.json");
+    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_ok());
     assert_eq!(0, deserialized.items.len());
@@ -27,8 +27,8 @@ fn success_parse_index_ops_errors_only() {
 
 #[test]
 fn success_parse_multi_ops() {
-    let s = load_file_as_response(200, "tests/samples/bulk_multiple_ops.json");
-    let deserialized = s.into_response::<BulkResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_multiple_ops.json");
+    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_ok());
 
@@ -51,8 +51,8 @@ fn success_parse_multi_ops() {
 
 #[test]
 fn success_parse_multi_ops_errors_only() {
-    let s = load_file_as_response(200, "tests/samples/bulk_multiple_ops.json");
-    let deserialized = s.into_response::<BulkErrorsResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_multiple_ops.json");
+    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_ok());
     assert_eq!(0, deserialized.items.len());
@@ -60,8 +60,8 @@ fn success_parse_multi_ops_errors_only() {
 
 #[test]
 fn success_parse_with_errors() {
-    let s = load_file_as_response(200, "tests/samples/bulk_error.json");
-    let deserialized = s.into_response::<BulkResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_error.json");
+    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_err());
 
@@ -71,8 +71,8 @@ fn success_parse_with_errors() {
 
 #[test]
 fn success_parse_with_errors_errors_only() {
-    let s = load_file_as_response(200, "tests/samples/bulk_error.json");
-    let deserialized = s.into_response::<BulkErrorsResponse>().unwrap();
+    let f = load_file("tests/samples/bulk_error.json");
+    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.is_err());
 
@@ -81,8 +81,8 @@ fn success_parse_with_errors_errors_only() {
 
 #[test]
 fn error_parse_action_request_validation() {
-    let s = load_file_as_response(400, "tests/samples/error_action_request_validation.json");
-    let deserialized = s.into_response::<BulkResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_action_request_validation.json");
+    let deserialized = parse::<BulkResponse>().from_read(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::ActionRequestValidation { ref reason })
@@ -95,8 +95,8 @@ fn error_parse_action_request_validation() {
 
 #[test]
 fn error_parse_action_request_validation_errors_only() {
-    let s = load_file_as_response(400, "tests/samples/error_action_request_validation.json");
-    let deserialized = s.into_response::<BulkErrorsResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_action_request_validation.json");
+    let deserialized = parse::<BulkErrorsResponse>().from_read(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::ActionRequestValidation { ref reason })

--- a/tests/bulk/mod.rs
+++ b/tests/bulk/mod.rs
@@ -8,7 +8,7 @@ use ::load_file;
 #[test]
 fn success_parse_index_ops() {
     let f = load_file("tests/samples/bulk_index.json");
-    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_ok());
 
@@ -19,7 +19,7 @@ fn success_parse_index_ops() {
 #[test]
 fn success_parse_index_ops_errors_only() {
     let f = load_file("tests/samples/bulk_index.json");
-    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkErrorsResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_ok());
     assert_eq!(0, deserialized.items.len());
@@ -28,7 +28,7 @@ fn success_parse_index_ops_errors_only() {
 #[test]
 fn success_parse_multi_ops() {
     let f = load_file("tests/samples/bulk_multiple_ops.json");
-    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_ok());
 
@@ -52,7 +52,7 @@ fn success_parse_multi_ops() {
 #[test]
 fn success_parse_multi_ops_errors_only() {
     let f = load_file("tests/samples/bulk_multiple_ops.json");
-    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkErrorsResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_ok());
     assert_eq!(0, deserialized.items.len());
@@ -61,7 +61,7 @@ fn success_parse_multi_ops_errors_only() {
 #[test]
 fn success_parse_with_errors() {
     let f = load_file("tests/samples/bulk_error.json");
-    let deserialized = parse::<BulkResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_err());
 
@@ -72,7 +72,7 @@ fn success_parse_with_errors() {
 #[test]
 fn success_parse_with_errors_errors_only() {
     let f = load_file("tests/samples/bulk_error.json");
-    let deserialized = parse::<BulkErrorsResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<BulkErrorsResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.is_err());
 
@@ -82,7 +82,7 @@ fn success_parse_with_errors_errors_only() {
 #[test]
 fn error_parse_action_request_validation() {
     let f = load_file("tests/samples/error_action_request_validation.json");
-    let deserialized = parse::<BulkResponse>().from_read(400, f).unwrap_err();
+    let deserialized = parse::<BulkResponse>().from_reader(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::ActionRequestValidation { ref reason })
@@ -96,7 +96,7 @@ fn error_parse_action_request_validation() {
 #[test]
 fn error_parse_action_request_validation_errors_only() {
     let f = load_file("tests/samples/error_action_request_validation.json");
-    let deserialized = parse::<BulkErrorsResponse>().from_read(400, f).unwrap_err();
+    let deserialized = parse::<BulkErrorsResponse>().from_reader(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::ActionRequestValidation { ref reason })

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -1,0 +1,13 @@
+extern crate elastic_responses;
+extern crate serde_json;
+
+use elastic_responses::*;
+use ::load_file;
+
+#[test]
+fn success_parse_command_response() {
+    let f = load_file("tests/samples/acknowledged.json");
+    let deserialized = parse::<CommandResponse>().from_read(200, f).unwrap();
+
+    assert!(deserialized.acknowledged);
+}

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -7,7 +7,7 @@ use ::load_file;
 #[test]
 fn success_parse_command_response() {
     let f = load_file("tests/samples/acknowledged.json");
-    let deserialized = parse::<CommandResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<CommandResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.acknowledged);
 }

--- a/tests/get/mod.rs
+++ b/tests/get/mod.rs
@@ -3,12 +3,12 @@ extern crate serde_json;
 
 use elastic_responses::*;
 use elastic_responses::error::*;
-use ::load_file_as_response;
+use ::load_file;
 
 #[test]
 fn success_parse_found_doc_response() {
-    let s = load_file_as_response(200, "tests/samples/get_found.json");
-    let deserialized = s.into_response::<GetResponse>().unwrap();
+    let f = load_file("tests/samples/get_found.json");
+    let deserialized = parse::<GetResponse>().from_read(200, f).unwrap();
 
     let id = deserialized.source
         .unwrap()
@@ -26,16 +26,16 @@ fn success_parse_found_doc_response() {
 
 #[test]
 fn success_parse_not_found_doc_response() {
-    let s = load_file_as_response(404, "tests/samples/get_not_found.json");
-    let deserialized = s.into_response::<GetResponse>().unwrap();
+    let f = load_file("tests/samples/get_not_found.json");
+    let deserialized = parse::<GetResponse>().from_read(404, f).unwrap();
 
     assert!(!deserialized.found);
 }
 
 #[test]
 fn error_parse_index_not_found() {
-    let s = load_file_as_response(404, "tests/samples/error_index_not_found.json");
-    let deserialized = s.into_response::<GetResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_index_not_found.json");
+    let deserialized = parse::<GetResponse>().from_read(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::IndexNotFound { ref index })

--- a/tests/get/mod.rs
+++ b/tests/get/mod.rs
@@ -8,7 +8,7 @@ use ::load_file;
 #[test]
 fn success_parse_found_doc_response() {
     let f = load_file("tests/samples/get_found.json");
-    let deserialized = parse::<GetResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<GetResponse>().from_reader(200, f).unwrap();
 
     let id = deserialized.source
         .unwrap()
@@ -27,7 +27,7 @@ fn success_parse_found_doc_response() {
 #[test]
 fn success_parse_not_found_doc_response() {
     let f = load_file("tests/samples/get_not_found.json");
-    let deserialized = parse::<GetResponse>().from_read(404, f).unwrap();
+    let deserialized = parse::<GetResponse>().from_reader(404, f).unwrap();
 
     assert!(!deserialized.found);
 }
@@ -35,7 +35,7 @@ fn success_parse_not_found_doc_response() {
 #[test]
 fn error_parse_index_not_found() {
     let f = load_file("tests/samples/error_index_not_found.json");
-    let deserialized = parse::<GetResponse>().from_read(404, f).unwrap_err();
+    let deserialized = parse::<GetResponse>().from_reader(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::IndexNotFound { ref index })

--- a/tests/get/mod.rs
+++ b/tests/get/mod.rs
@@ -19,6 +19,7 @@ fn success_parse_found_doc_response() {
     assert!(deserialized.found);
     assert_eq!("testindex", deserialized.index);
     assert_eq!("testtype", deserialized.ty);
+    assert_eq!("1", deserialized.id);
     assert_eq!(Some(8), deserialized.version);
     assert_eq!(Some(1), id);
 }

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -1,0 +1,32 @@
+extern crate elastic_responses;
+extern crate serde_json;
+
+use elastic_responses::*;
+use elastic_responses::error::*;
+use ::load_file_as_response;
+
+#[test]
+fn success_parse_response() {
+    let s = load_file_as_response(200, "tests/samples/index_success.json");
+    let deserialized = s.into_response::<IndexResponse>().unwrap();
+
+    assert!(deserialized.created);
+    assert_eq!("testindex", deserialized.index);
+    assert_eq!("testtype", deserialized.ty);
+    assert_eq!("1", deserialized.id);
+    assert_eq!(Some(1), deserialized.version);
+}
+
+#[test]
+fn error_parse_mapping() {
+    let s = load_file_as_response(404, "tests/samples/error_mapper_parsing.json");
+    let deserialized = s.into_response::<IndexResponse>().unwrap_err();
+
+    let valid = match deserialized {
+        ResponseError::Api(ApiError::MapperParsing { ref reason })
+        if reason == "failed to parse, document is empty" => true,
+        _ => false
+    };
+
+    assert!(valid);
+}

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -3,12 +3,12 @@ extern crate serde_json;
 
 use elastic_responses::*;
 use elastic_responses::error::*;
-use ::load_file_as_response;
+use ::load_file;
 
 #[test]
 fn success_parse_response() {
-    let s = load_file_as_response(200, "tests/samples/index_success.json");
-    let deserialized = s.into_response::<IndexResponse>().unwrap();
+    let f = load_file("tests/samples/index_success.json");
+    let deserialized = parse::<IndexResponse>().from_read(200, f).unwrap();
 
     assert!(deserialized.created);
     assert_eq!("testindex", deserialized.index);
@@ -19,8 +19,8 @@ fn success_parse_response() {
 
 #[test]
 fn error_parse_mapping() {
-    let s = load_file_as_response(404, "tests/samples/error_mapper_parsing.json");
-    let deserialized = s.into_response::<IndexResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_mapper_parsing.json");
+    let deserialized = parse::<IndexResponse>().from_read(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::MapperParsing { ref reason })

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -8,7 +8,7 @@ use ::load_file;
 #[test]
 fn success_parse_response() {
     let f = load_file("tests/samples/index_success.json");
-    let deserialized = parse::<IndexResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<IndexResponse>().from_reader(200, f).unwrap();
 
     assert!(deserialized.created);
     assert_eq!("testindex", deserialized.index);
@@ -20,7 +20,7 @@ fn success_parse_response() {
 #[test]
 fn error_parse_mapping() {
     let f = load_file("tests/samples/error_mapper_parsing.json");
-    let deserialized = parse::<IndexResponse>().from_read(404, f).unwrap_err();
+    let deserialized = parse::<IndexResponse>().from_reader(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::MapperParsing { ref reason })

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,9 +1,7 @@
 extern crate elastic_responses;
 extern crate serde_json;
 
-use elastic_responses::*;
 use std::fs::File;
-use std::io::{Read, Cursor};
 
 fn load_file(p: &str) -> File {
     File::open(p).unwrap()

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,33 +5,11 @@ use elastic_responses::*;
 use std::fs::File;
 use std::io::{Read, Cursor};
 
-fn load_file_as_response(status: u16, p: &str) -> HttpResponseRead<Cursor<Vec<u8>>> {
-    let mut f = File::open(p).unwrap();
-    let mut s = Vec::new();
-    f.read_to_end(&mut s).unwrap();
-    
-    HttpResponse::from_read(status, Cursor::new(s))
+fn load_file(p: &str) -> File {
+    File::open(p).unwrap()
 }
 
-#[test]
-fn test_read_response() {
-    let mut res = HttpResponse::from_read(200, Cursor::new(vec![1, 2, 3]));
-
-    let mut actual = Vec::new();
-    res.read_to_end(&mut actual).unwrap();
-
-    let expected = vec![1, 2, 3];
-
-    assert_eq!(expected, actual);
-}
-
-#[test]
-fn test_as_ref_response() {
-    let res = HttpResponse::from_slice(200, vec![1, 2, 3]);
-
-    assert_eq!(&[1, 2, 3], res.as_ref());
-}
-
+pub mod command;
 pub mod ping;
 pub mod get;
 pub mod search;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -36,3 +36,4 @@ pub mod ping;
 pub mod get;
 pub mod search;
 pub mod bulk;
+pub mod index;

--- a/tests/ping/mod.rs
+++ b/tests/ping/mod.rs
@@ -7,7 +7,7 @@ use ::load_file;
 #[test]
 fn success_parse_ping_response() {
     let f = load_file("tests/samples/ping_success.json");
-    let deserialized = parse::<PingResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<PingResponse>().from_reader(200, f).unwrap();
 
     assert_eq!("Scorcher", &deserialized.name);
 }

--- a/tests/ping/mod.rs
+++ b/tests/ping/mod.rs
@@ -2,12 +2,12 @@ extern crate elastic_responses;
 extern crate serde_json;
 
 use elastic_responses::*;
-use ::load_file_as_response;
+use ::load_file;
 
 #[test]
 fn success_parse_ping_response() {
-    let s = load_file_as_response(200, "tests/samples/ping_success.json");
-    let deserialized = s.into_response::<PingResponse>().unwrap();
+    let f = load_file("tests/samples/ping_success.json");
+    let deserialized = parse::<PingResponse>().from_read(200, f).unwrap();
 
     assert_eq!("Scorcher", &deserialized.name);
 }

--- a/tests/samples/acknowledged.json
+++ b/tests/samples/acknowledged.json
@@ -1,0 +1,3 @@
+{
+  "acknowledged": true
+}

--- a/tests/samples/error_mapper_parsing.json
+++ b/tests/samples/error_mapper_parsing.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "mapper_parsing_exception",
+        "reason": "failed to parse, document is empty"
+      }
+    ],
+    "type": "mapper_parsing_exception",
+    "reason": "failed to parse, document is empty"
+  },
+  "status": 400
+}

--- a/tests/samples/index_success.json
+++ b/tests/samples/index_success.json
@@ -1,0 +1,12 @@
+{
+  "_index": "testindex",
+  "_type": "testtype",
+  "_id": "1",
+  "_version": 1,
+  "_shards": {
+    "total": 2,
+    "successful": 1,
+    "failed": 0
+  },
+  "created": true
+}

--- a/tests/search/mod.rs
+++ b/tests/search/mod.rs
@@ -4,52 +4,52 @@ extern crate serde_json;
 use elastic_responses::*;
 use elastic_responses::error::*;
 use serde_json::Value;
-use ::load_file_as_response;
+use ::load_file;
 
 #[test]
 fn success_parse_empty() {
-    let s = load_file_as_response(200, "tests/samples/search_empty.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_empty.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 0);
 }
 
 #[test]
 fn success_parse_hits_simple() {
-    let s = load_file_as_response(200, "tests/samples/search_hits_only.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_hits_only.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 5);
 }
 
 #[test]
 fn success_parse_hits_no_score() {
-    let s = load_file_as_response(200, "tests/samples/search_null_score.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_null_score.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 1);
 }
 
 #[test]
 fn success_parse_simple_aggs() {
-    let s = load_file_as_response(200, "tests/samples/search_aggregation_simple.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_aggregation_simple.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 124);
 }
 
 #[test]
 fn success_parse_3level_aggs() {
-    let s = load_file_as_response(200, "tests/samples/search_aggregation_3level.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_aggregation_3level.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 201);
 }
 
 #[test]
 fn success_parse_3level_multichild_aggs() {
-    let s = load_file_as_response(200, "tests/samples/search_aggregation_3level_multichild.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_aggregation_3level_multichild.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     let min = "min_ack_pkts_sent";
     let avg = "avg_ack_pkts_sent";
@@ -70,8 +70,8 @@ fn success_parse_3level_multichild_aggs() {
 
 #[test]
 fn success_parse_3level_multistats_aggs() {
-    let s = load_file_as_response(200, "tests/samples/search_aggregation_3level_multistats.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_aggregation_3level_multistats.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
     let min = "extstats_ack_pkts_sent_min";
     let avg = "stats_ack_pkts_sent_avg";
@@ -94,14 +94,14 @@ fn success_parse_3level_multistats_aggs() {
 
 #[test]
 fn success_parse_simple_aggs_no_empty_first_record() {
-    let s = load_file_as_response(200, "tests/samples/search_aggregation_simple.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap();
+    let f = load_file("tests/samples/search_aggregation_simple.json");
+    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
 
-    let s = "timechart";
+    let agg = "timechart";
     let mut first = true;
     for i in deserialized.aggs().into_iter().take(50) {
         if first {
-            assert!(i.contains_key(s));
+            assert!(i.contains_key(agg));
             first = false;
         }
     }
@@ -109,16 +109,16 @@ fn success_parse_simple_aggs_no_empty_first_record() {
 
 #[test]
 fn success_parse_hits_simple_as_value() {
-    let s = load_file_as_response(200, "tests/samples/search_hits_only.json");
-    let deserialized = s.into_response::<Value>().unwrap();
+    let f = load_file("tests/samples/search_hits_only.json");
+    let deserialized = parse::<Value>().from_read(200, f).unwrap();
 
     assert_eq!(deserialized["_shards"]["total"].as_u64().unwrap(), 5);
 }
 
 #[test]
 fn error_parse_index_not_found() {
-    let s = load_file_as_response(404, "tests/samples/error_index_not_found.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_index_not_found.json");
+    let deserialized = parse::<SearchResponse>().from_read(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::IndexNotFound { ref index })
@@ -131,8 +131,8 @@ fn error_parse_index_not_found() {
 
 #[test]
 fn error_parse_parsing() {
-    let s = load_file_as_response(400, "tests/samples/error_parsing.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_parsing.json");
+    let deserialized = parse::<SearchResponse>().from_read(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::Parsing { line: 2, col: 9, ref reason })
@@ -145,8 +145,8 @@ fn error_parse_parsing() {
 
 #[test]
 fn error_parse_other() {
-    let s = load_file_as_response(500, "tests/samples/error_other.json");
-    let deserialized = s.into_response::<SearchResponse>().unwrap_err();
+    let f = load_file("tests/samples/error_other.json");
+    let deserialized = parse::<SearchResponse>().from_read(500, f).unwrap_err();
 
     let reason = match deserialized {
         ResponseError::Api(ApiError::Other(ref err)) => err.get("reason")

--- a/tests/search/mod.rs
+++ b/tests/search/mod.rs
@@ -9,7 +9,7 @@ use ::load_file;
 #[test]
 fn success_parse_empty() {
     let f = load_file("tests/samples/search_empty.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 0);
 }
@@ -17,7 +17,7 @@ fn success_parse_empty() {
 #[test]
 fn success_parse_hits_simple() {
     let f = load_file("tests/samples/search_hits_only.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 5);
 }
@@ -25,7 +25,7 @@ fn success_parse_hits_simple() {
 #[test]
 fn success_parse_hits_no_score() {
     let f = load_file("tests/samples/search_null_score.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized.hits().into_iter().count(), 1);
 }
@@ -33,7 +33,7 @@ fn success_parse_hits_no_score() {
 #[test]
 fn success_parse_simple_aggs() {
     let f = load_file("tests/samples/search_aggregation_simple.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 124);
 }
@@ -41,7 +41,7 @@ fn success_parse_simple_aggs() {
 #[test]
 fn success_parse_3level_aggs() {
     let f = load_file("tests/samples/search_aggregation_3level.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized.aggs().into_iter().count(), 201);
 }
@@ -49,7 +49,7 @@ fn success_parse_3level_aggs() {
 #[test]
 fn success_parse_3level_multichild_aggs() {
     let f = load_file("tests/samples/search_aggregation_3level_multichild.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     let min = "min_ack_pkts_sent";
     let avg = "avg_ack_pkts_sent";
@@ -71,7 +71,7 @@ fn success_parse_3level_multichild_aggs() {
 #[test]
 fn success_parse_3level_multistats_aggs() {
     let f = load_file("tests/samples/search_aggregation_3level_multistats.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     let min = "extstats_ack_pkts_sent_min";
     let avg = "stats_ack_pkts_sent_avg";
@@ -95,7 +95,7 @@ fn success_parse_3level_multistats_aggs() {
 #[test]
 fn success_parse_simple_aggs_no_empty_first_record() {
     let f = load_file("tests/samples/search_aggregation_simple.json");
-    let deserialized = parse::<SearchResponse>().from_read(200, f).unwrap();
+    let deserialized = parse::<SearchResponse>().from_reader(200, f).unwrap();
 
     let agg = "timechart";
     let mut first = true;
@@ -110,7 +110,7 @@ fn success_parse_simple_aggs_no_empty_first_record() {
 #[test]
 fn success_parse_hits_simple_as_value() {
     let f = load_file("tests/samples/search_hits_only.json");
-    let deserialized = parse::<Value>().from_read(200, f).unwrap();
+    let deserialized = parse::<Value>().from_reader(200, f).unwrap();
 
     assert_eq!(deserialized["_shards"]["total"].as_u64().unwrap(), 5);
 }
@@ -118,7 +118,7 @@ fn success_parse_hits_simple_as_value() {
 #[test]
 fn error_parse_index_not_found() {
     let f = load_file("tests/samples/error_index_not_found.json");
-    let deserialized = parse::<SearchResponse>().from_read(404, f).unwrap_err();
+    let deserialized = parse::<SearchResponse>().from_reader(404, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::IndexNotFound { ref index })
@@ -132,7 +132,7 @@ fn error_parse_index_not_found() {
 #[test]
 fn error_parse_parsing() {
     let f = load_file("tests/samples/error_parsing.json");
-    let deserialized = parse::<SearchResponse>().from_read(400, f).unwrap_err();
+    let deserialized = parse::<SearchResponse>().from_reader(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::Parsing { line: 2, col: 9, ref reason })
@@ -146,7 +146,7 @@ fn error_parse_parsing() {
 #[test]
 fn error_parse_other() {
     let f = load_file("tests/samples/error_other.json");
-    let deserialized = parse::<SearchResponse>().from_read(500, f).unwrap_err();
+    let deserialized = parse::<SearchResponse>().from_reader(500, f).unwrap_err();
 
     let reason = match deserialized {
         ResponseError::Api(ApiError::Other(ref err)) => err.get("reason")


### PR DESCRIPTION
Closes #34 

- Removes `HttpResponse` type in favour of individual parsing methods
- Adds `IndexResponse` and the common acknowledgement response