### PR TITLE
Use doc comment blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ Query your Elasticsearch Cluster, then iterate through the results:
 let mut res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
 
 // Parse body to JSON
-let body_as_json = parse::<SearchResponse<Value>>().from_reader(res.status().to_u16(), res).unwrap();
+let response = parse::<SearchResponse<Value>>().from_reader(res.status().to_u16(), res).unwrap();
 
 // Use hits() or aggs() iterators
 // Hits
-for hit in body_as_json.hits() {
+for hit in response.hits() {
     println!("{:?}", hit);
 }
 
 // Agregations
-for agg in body_as_json.aggs() {
+for agg in response.aggs() {
     println!("{:?}", agg);
 }
 ```
@@ -55,9 +55,9 @@ Bulk response operations are split by whether they succeeded or failed:
 let mut res = client.elastic_req(&params, BulkRequest::new(body)).unwrap();
 
 // Parse body to JSON
-let body_as_json = parse::<BulkResponse>().from_reader(res.status().to_u16(), res).unwrap();
+let response = parse::<BulkResponse>().from_reader(res.status().to_u16(), res).unwrap();
 
-for op in body_as_json.into_iter() {
+for op in response.into_iter() {
     match op {
         Ok(ok) => {
             // Do something with successful operations

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,4 +1,6 @@
-//! Response types for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+/*!
+Response types for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+*/
 
 use serde::de::{Deserialize, Deserializer, Visitor, Error as DeError, SeqAccess, MapAccess};
 use serde_json::Value;
@@ -16,125 +18,127 @@ use std::error::Error;
 
 type BulkError = Value;
 
-/// Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
-/// 
-/// Individual bulk items are a `Result` of [`OkItem`](struct.OkItem.html) or [`ErrorItem`](struct.ErrorItem.html) and can be iterated over.
-/// Any individual bulk item may be an `Err(ErrorItem)`, so it's important to check them.
-/// The `is_ok` and `is_err` methods on `BulkResponse` make it easier to assert there are no errors.
-/// 
-/// # Examples
-/// 
-/// Send a bulk request and iterate through the results:
-/// 
-/// ```no_run
-/// # extern crate elastic_responses;
-/// # use elastic_responses::*;
-/// # fn do_request() -> BulkResponse { unimplemented!() }
-/// # fn main() {
-/// let response: BulkResponse = do_request();
-/// 
-/// // Check if the response contains any errors
-/// if response.is_err() {
-///     println!("some bulk items failed");
-/// }
-///
-/// // Iterate through all items
-/// for item in response {
-///     match item {
-///         Ok(item) => {
-///             // Do something with the `OkItem`s
-///             println!("ok: {:?}", item)
-///         },
-///         Err(item) => {
-///             // Do something with the `ErrorItem`s
-///             println!("err: {:?}", item)
-///         }
-///     }
-/// }
-/// # }
-/// ```
-/// 
-/// Use `iter` to iterate over individual items without taking ownership of them:
-/// 
-/// ```no_run
-/// # extern crate elastic_responses;
-/// # use elastic_responses::*;
-/// # fn do_request() -> BulkResponse { unimplemented!() }
-/// # fn main() {
-/// let response: BulkResponse = do_request();
-///
-/// // Do something with successful items for index `myindex`
-/// let item_iter = response.iter()
-///                         .filter_map(Result::ok)
-///                         .filter(|o| o.index() == "myindex");
-/// 
-/// for item in item_iter {
-///     // Do something with the `OkItem`s
-///     println!("ok: {:?}", item);
-/// }
-/// # }
-/// ```
-/// 
-/// # Optimising bulk responses
-/// 
-/// If you're only interested in bulk items that failed, see [`BulkErrorsResponse`](struct.BulkErrorsResponse.html).
-/// It can avoid allocating bulk item responses that will never be processed.
-/// 
-/// Both the `BulkResponse` and `BulkErrorsResponse` types have generic parameters for the index, type and id fields.
-/// If your bulk items have a small set of possible values for these fields you can avoid
-/// allocating `String`s on the heap by using an alternative type, like an `enum`.
-/// 
-/// In the example below, we expect all bulk items to use either a type called `mytypea` or `mytypeb`
-/// and an index called `myindex`:
-/// 
-/// ```no_run
-/// # extern crate serde;
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde_json;
-/// # extern crate elastic_responses;
-/// # use elastic_responses::*;
-/// # fn main() {
-/// # fn do_request() -> BulkResponse<Index, Type> { unimplemented!() }
-/// #[derive(Deserialize)]
-/// #[serde(rename_all = "lowercase")]
-/// enum Index {
-///     MyIndex,
-/// }
-/// 
-/// #[derive(Deserialize)]
-/// #[serde(rename_all = "lowercase")]
-/// enum Type {
-///     MyTypeA,
-///     MyTypeB,
-/// }
-/// 
-/// let bulk: BulkResponse<Index, Type> = do_request();
-/// # }
-/// ```
-/// 
-/// Other crates that can avoid allocating strings:
-/// 
-/// - [`string-cache`](https://github.com/servo/string-cache) crate for interning string values
-/// - [`inlinable-string`](https://github.com/fitzgen/inlinable_string) crate for storing small strings on the stack
-/// 
-/// # Taking `BulkResonse` as an argument
-/// 
-/// The `BulkResponse` type has three default generic parameters for the index, type and id fields.
-/// If you need to accept a `BulkResponse` as a function argument, you should specify these generics.
-/// Otherwise the function will only accept a default `BulkResponse`:
-/// 
-/// ```
-/// # use elastic_responses::*;
-/// // Do: Supports any BulkResponse
-/// fn takes_any_response<TIndex, TType, TId>(res: BulkResponse<TIndex, TType, TId>) { 
-/// 
-/// }
-/// 
-/// // Don't: Only supports default BulkResponse
-/// fn takes_default_response(res: BulkResponse) {
-/// 
-/// }
-/// ```
+/**
+Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+
+Individual bulk items are a `Result` of [`OkItem`](struct.OkItem.html) or [`ErrorItem`](struct.ErrorItem.html) and can be iterated over.
+Any individual bulk item may be an `Err(ErrorItem)`, so it's important to check them.
+The `is_ok` and `is_err` methods on `BulkResponse` make it easier to assert there are no errors.
+
+# Examples
+
+Send a bulk request and iterate through the results:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn do_request() -> BulkResponse { unimplemented!() }
+# fn main() {
+let response: BulkResponse = do_request();
+
+// Check if the response contains any errors
+if response.is_err() {
+    println!("some bulk items failed");
+}
+
+// Iterate through all items
+for item in response {
+    match item {
+        Ok(item) => {
+            // Do something with the `OkItem`s
+            println!("ok: {:?}", item)
+        },
+        Err(item) => {
+            // Do something with the `ErrorItem`s
+            println!("err: {:?}", item)
+        }
+    }
+}
+# }
+```
+
+Use `iter` to iterate over individual items without taking ownership of them:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn do_request() -> BulkResponse { unimplemented!() }
+# fn main() {
+let response: BulkResponse = do_request();
+
+// Do something with successful items for index `myindex`
+let item_iter = response.iter()
+                        .filter_map(Result::ok)
+                        .filter(|o| o.index() == "myindex");
+
+for item in item_iter {
+    // Do something with the `OkItem`s
+    println!("ok: {:?}", item);
+}
+# }
+```
+
+# Optimising bulk responses
+
+If you're only interested in bulk items that failed, see [`BulkErrorsResponse`](struct.BulkErrorsResponse.html).
+It can avoid allocating bulk item responses that will never be processed.
+
+Both the `BulkResponse` and `BulkErrorsResponse` types have generic parameters for the index, type and id fields.
+If your bulk items have a small set of possible values for these fields you can avoid
+allocating `String`s on the heap by using an alternative type, like an `enum`.
+
+In the example below, we expect all bulk items to use either a type called `mytypea` or `mytypeb`
+and an index called `myindex`:
+
+```no_run
+# extern crate serde;
+# #[macro_use] extern crate serde_derive;
+# extern crate serde_json;
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn main() {
+# fn do_request() -> BulkResponse<Index, Type> { unimplemented!() }
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Index {
+    MyIndex,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Type {
+    MyTypeA,
+    MyTypeB,
+}
+
+let bulk: BulkResponse<Index, Type> = do_request();
+# }
+```
+
+Other crates that can avoid allocating strings:
+
+- [`string-cache`](https://github.com/servo/string-cache) crate for interning string values
+- [`inlinable-string`](https://github.com/fitzgen/inlinable_string) crate for storing small strings on the stack
+
+# Taking `BulkResonse` as an argument
+
+The `BulkResponse` type has three default generic parameters for the index, type and id fields.
+If you need to accept a `BulkResponse` as a function argument, you should specify these generics.
+Otherwise the function will only accept a default `BulkResponse`:
+
+```
+# use elastic_responses::*;
+// Do: Supports any BulkResponse
+fn takes_any_response<TIndex, TType, TId>(res: BulkResponse<TIndex, TType, TId>) { 
+
+}
+
+// Don't: Only supports default BulkResponse
+fn takes_default_response(res: BulkResponse) {
+
+}
+```
+*/
 #[derive(Deserialize, Debug, Clone)]
 #[serde(bound(deserialize = "TIndex: Deserialize<'de>, TType: Deserialize<'de>, TId: Deserialize<'de>"))]
 pub struct BulkResponse<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
@@ -145,54 +149,56 @@ pub struct BulkResponse<TIndex = DefaultAllocatedField, TType = DefaultAllocated
 }
 
 impl<TIndex, TType, TId> BulkResponse<TIndex, TType, TId> {
-    /// Time in milliseconds it took for Elasticsearch to process the request.
+    /** Time in milliseconds it took for Elasticsearch to process the request. */
     pub fn took(&self) -> u64 {
         self.took
     }
 
-    /// Returns `true` if all bulk items succeeded.
+    /** Returns `true` if all bulk items succeeded. */
     pub fn is_ok(&self) -> bool {
         !self.errors
     }
 
-    /// Returns `true` if any bulk items failed.
+    /** Returns `true` if any bulk items failed. */
     pub fn is_err(&self) -> bool {
         self.errors
     }
 
-    /// Iterate through the bulk items.
-    /// 
-    /// The items in this iterator are a standard `Result` where `Ok` means the item succeeded
-    /// and `Err` means it failed.
-    /// 
-    /// To move out of the items in a `BulkResponse` instead of borrowing them, call `into_iter`.
-    /// 
-    /// # Examples
-    /// 
-    /// Iterate through the individual items in a `BulkResponse`:
-    /// 
-    /// ```no_run
-    /// # extern crate elastic_responses;
-    /// # use elastic_responses::*;
-    /// # fn do_request() -> BulkResponse { unimplemented!() }
-    /// # fn main() {
-    /// let response: BulkResponse = do_request();
-    /// 
-    /// // Iterate through all items
-    /// for item in response.iter() {
-    ///     match item {
-    ///         Ok(ref item) => {
-    ///             // Do something with the `OkItem`s
-    ///             println!("ok: {:?}", item)
-    ///         },
-    ///         Err(ref item) => {
-    ///             // Do something with the `ErrorItem`s
-    ///             println!("err: {:?}", item)
-    ///         }
-    ///     }
-    /// }
-    /// # }
-    /// ```
+    /**
+    Iterate through the bulk items.
+    
+    The items in this iterator are a standard `Result` where `Ok` means the item succeeded
+    and `Err` means it failed.
+    
+    To move out of the items in a `BulkResponse` instead of borrowing them, call `into_iter`.
+    
+    # Examples
+    
+    Iterate through the individual items in a `BulkResponse`:
+    
+    ```no_run
+    # extern crate elastic_responses;
+    # use elastic_responses::*;
+    # fn do_request() -> BulkResponse { unimplemented!() }
+    # fn main() {
+    let response: BulkResponse = do_request();
+    
+    // Iterate through all items
+    for item in response.iter() {
+        match item {
+            Ok(ref item) => {
+                // Do something with the `OkItem`s
+                println!("ok: {:?}", item)
+            },
+            Err(ref item) => {
+                // Do something with the `ErrorItem`s
+                println!("err: {:?}", item)
+            }
+        }
+    }
+    # }
+    ```
+    */
     pub fn iter(&self) -> ResultIter<TIndex, TType, TId> {
         ResultIter(self.items.iter())
     }
@@ -207,7 +213,7 @@ impl<TIndex, TType, TId> IntoIterator for BulkResponse<TIndex, TType, TId> {
     }
 }
 
-/// An owning iterator for a bulk item that may have succeeded or failed.
+/** An owning iterator for a bulk item that may have succeeded or failed. */
 pub struct ResultIntoIter<TIndex, TType, TId>(IntoIter<ItemResult<TIndex, TType, TId>>);
 
 impl<TIndex, TType, TId> Iterator for ResultIntoIter<TIndex, TType, TId> {
@@ -218,7 +224,7 @@ impl<TIndex, TType, TId> Iterator for ResultIntoIter<TIndex, TType, TId> {
     }
 }
 
-/// A borrowing iterator for a bulk item that may have succeeded or failed.
+/** A borrowing iterator for a bulk item that may have succeeded or failed. */
 pub struct ResultIter<'a, TIndex: 'a, TType: 'a, TId: 'a>(Iter<'a, ItemResult<TIndex, TType, TId>>);
 
 impl<'a, TIndex: 'a, TType: 'a, TId: 'a> Iterator for ResultIter<'a, TIndex, TType, TId> {
@@ -229,71 +235,73 @@ impl<'a, TIndex: 'a, TType: 'a, TId: 'a> Iterator for ResultIter<'a, TIndex, TTy
     }
 }
 
-/// Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
-/// 
-/// This type only accumulates bulk items that failed.
-/// It can be more efficient if you only care about errors.
-/// Individual bulk items are [`ErrorItem`](struct.ErrorItem.html) and can be iterated over.
-/// 
-/// # Examples
-/// 
-/// Send a bulk request and iterate through the errors:
-/// 
-/// ```no_run
-/// # extern crate elastic_responses;
-/// # use elastic_responses::*;
-/// # use elastic_responses::bulk::Action;
-/// # fn do_request() -> BulkErrorsResponse { unimplemented!() }
-/// # fn main() {
-/// let response: BulkErrorsResponse = do_request();
-/// 
-/// // Do something with failed items
-/// for item in response {
-///     match item.action() {
-///         Action::Delete => (), // Ignore failed deletes
-///         _ => println!("err: {:?}", item) 
-///     }
-/// }
-/// # }
-/// ```
-///
-/// Use `iter` to iterate over individual errors without taking ownership of them:
-/// 
-/// ```no_run
-/// # extern crate elastic_responses;
-/// # use elastic_responses::*;
-/// # fn do_request() -> BulkErrorsResponse { unimplemented!() }
-/// # fn main() {
-/// let response: BulkErrorsResponse = do_request();
-///
-/// // Do something with errors for index `myindex`
-/// let item_iter = response.iter()
-///                         .filter(|o| o.index() == "myindex");
-/// 
-/// for item in item_iter {
-///     println!("err: {:?}", item);
-/// }
-/// # }
-/// ```
-///
-/// # Taking `BulkErrorsResponse` as an argument
-/// 
-/// The `BulkErrorsResponse` type has three default generic parameters for the index, type and id fields.
-/// If you need to accept a `BulkErrorsResponse` as a function argument, you should specify these generics.
-/// Otherwise the function will only accept a default `BulkErrorsResponse`:
-/// 
-/// ```
-/// # use elastic_responses::*;
-/// // Do: Supports any BulkErrorsResponse
-/// fn takes_any_response<TIndex, TType, TId>(res: BulkErrorsResponse<TIndex, TType, TId>) { 
-/// 
-/// }
-/// 
-/// // Don't: Only supports default BulkErrorsResponse
-/// fn takes_default_response(res: BulkErrorsResponse) {
-/// 
-/// }
-/// ```
+/**
+Response for a [bulk request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).
+
+This type only accumulates bulk items that failed.
+It can be more efficient if you only care about errors.
+Individual bulk items are [`ErrorItem`](struct.ErrorItem.html) and can be iterated over.
+
+# Examples
+
+Send a bulk request and iterate through the errors:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# use elastic_responses::bulk::Action;
+# fn do_request() -> BulkErrorsResponse { unimplemented!() }
+# fn main() {
+let response: BulkErrorsResponse = do_request();
+
+// Do something with failed items
+for item in response {
+    match item.action() {
+        Action::Delete => (), // Ignore failed deletes
+        _ => println!("err: {:?}", item) 
+    }
+}
+# }
+```
+
+Use `iter` to iterate over individual errors without taking ownership of them:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn do_request() -> BulkErrorsResponse { unimplemented!() }
+# fn main() {
+let response: BulkErrorsResponse = do_request();
+
+// Do something with errors for index `myindex`
+let item_iter = response.iter()
+                        .filter(|o| o.index() == "myindex");
+
+for item in item_iter {
+    println!("err: {:?}", item);
+}
+# }
+```
+
+# Taking `BulkErrorsResponse` as an argument
+
+The `BulkErrorsResponse` type has three default generic parameters for the index, type and id fields.
+If you need to accept a `BulkErrorsResponse` as a function argument, you should specify these generics.
+Otherwise the function will only accept a default `BulkErrorsResponse`:
+
+```
+# use elastic_responses::*;
+// Do: Supports any BulkErrorsResponse
+fn takes_any_response<TIndex, TType, TId>(res: BulkErrorsResponse<TIndex, TType, TId>) { 
+
+}
+
+// Don't: Only supports default BulkErrorsResponse
+fn takes_default_response(res: BulkErrorsResponse) {
+
+}
+```
+*/
 #[derive(Deserialize, Debug, Clone)]
 #[serde(bound(deserialize = "TIndex: Deserialize<'de>, TType: Deserialize<'de>, TId: Deserialize<'de>"))]
 pub struct BulkErrorsResponse<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
@@ -312,7 +320,7 @@ impl<TIndex, TType, TId> IntoIterator for BulkErrorsResponse<TIndex, TType, TId>
     }
 }
 
-/// An owning iterator for a bulk item that failed.
+/** An owning iterator for a bulk item that failed. */
 pub struct ErrorIntoIter<TIndex, TType, TId>(IntoIter<ErrorItem<TIndex, TType, TId>>);
 
 impl<TIndex, TType, TId> Iterator for ErrorIntoIter<TIndex, TType, TId> {
@@ -323,7 +331,7 @@ impl<TIndex, TType, TId> Iterator for ErrorIntoIter<TIndex, TType, TId> {
     }
 }
 
-/// A borrowing iterator for a bulk item that failed.
+/** A borrowing iterator for a bulk item that failed. */
 pub struct ErrorIter<'a, TIndex: 'a, TType: 'a, TId: 'a>(Iter<'a, ErrorItem<TIndex, TType, TId>>);
 
 impl<'a, TIndex: 'a, TType: 'a, TId: 'a> Iterator for ErrorIter<'a, TIndex, TType, TId> {
@@ -335,44 +343,45 @@ impl<'a, TIndex: 'a, TType: 'a, TId: 'a> Iterator for ErrorIter<'a, TIndex, TTyp
 }
 
 impl<TIndex, TType, TId> BulkErrorsResponse<TIndex, TType, TId> {
-    /// Time in milliseconds it took for Elasticsearch to process the request.
+    /** Time in milliseconds it took for Elasticsearch to process the request. */
     pub fn took(&self) -> u64 {
         self.took
     }
 
-    /// Returns `true` if all bulk items succeeded.
+    /** Returns `true` if all bulk items succeeded. */
     pub fn is_ok(&self) -> bool {
         !self.errors
     }
 
-    /// Returns `true` if any bulk itemss failed.
+    /** Returns `true` if any bulk itemss failed. */
     pub fn is_err(&self) -> bool {
         self.errors
     }
 
-    /// Iterate through the bulk item errors.
-    /// 
-    /// Items in this iterator all all errors that occurred while handling the bulk request.
-    /// 
-    /// # Examples
-    /// 
-    /// Iterate through the individual items in a `BulkErrorsResponse`:
-    /// 
-    /// ```no_run
-    /// # extern crate elastic_responses;
-    /// # use elastic_responses::*;
-    /// # fn do_request() -> BulkErrorsResponse { unimplemented!() }
-    /// # fn main() {
-    /// let response: BulkErrorsResponse = do_request();
-    /// 
-    /// // Iterate through all items
-    /// for item in response.iter() {
-    ///     // Do something with failed items
-    ///     println!("err: {:?}", item)
-    /// }
-    /// # }
-    /// ```
+    /** 
+    Iterate through the bulk item errors.
     
+    Items in this iterator all all errors that occurred while handling the bulk request.
+    
+    # Examples
+    
+    Iterate through the individual items in a `BulkErrorsResponse`:
+    
+    ```no_run
+    # extern crate elastic_responses;
+    # use elastic_responses::*;
+    # fn do_request() -> BulkErrorsResponse { unimplemented!() }
+    # fn main() {
+    let response: BulkErrorsResponse = do_request();
+    
+    // Iterate through all items
+    for item in response.iter() {
+        // Do something with failed items
+        println!("err: {:?}", item)
+    }
+    # }
+    ```
+    */
     pub fn iter(&self) -> ErrorIter<TIndex, TType, TId> {
         ErrorIter(self.items.iter())
     }
@@ -381,7 +390,7 @@ impl<TIndex, TType, TId> BulkErrorsResponse<TIndex, TType, TId> {
 type ItemResult<TIndex, TType, TId> = Result<OkItem<TIndex, TType, TId>, ErrorItem<TIndex, TType, TId>>;
 type ItemResultBrw<'a, TIndex, TType, TId> = Result<&'a OkItem<TIndex, TType, TId>, &'a ErrorItem<TIndex, TType, TId>>;
 
-/// A successful bulk response item.
+/** A successful bulk response item. */
 #[derive(Debug, Clone)]
 pub struct OkItem<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     action: Action,
@@ -395,47 +404,51 @@ pub struct OkItem<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField,
 }
 
 impl<TIndex, TType, TId> OkItem<TIndex, TType, TId> {
-    /// The bulk action for this item.
+    /** The bulk action for this item. */
     pub fn action(&self) -> Action {
         self.action
     }
 
-    /// The document version after this item.
+    /** The document version after this item. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
     }
 
-    /// Whether or not this item created the document.
-    /// 
-    /// `created` will only be `true` if the action is `Index` and the document didn't already exist.
+    /** 
+    Whether or not this item created the document.
+    
+    `created` will only be `true` if the action is `Index` and the document didn't already exist.
+    */
     pub fn created(&self) -> bool {
         self.created.clone().unwrap_or(false)
     }
 
-    /// Whether or not this item found the document.
-    /// 
-    /// `found` will only be `true` if the action is `Delete` and the document did already exist.
+    /** 
+    Whether or not this item found the document.
+    
+    `found` will only be `true` if the action is `Delete` and the document did already exist.
+    */
     pub fn found(&self) -> bool {
         self.found.clone().unwrap_or(false)
     }
     
-    /// The index for this item.
+    /** The index for this item. */
     pub fn index(&self) -> &TIndex {
         &self.index
     }
     
-    /// The document type for this item.
+    /** The document type for this item. */
     pub fn ty(&self) -> &TType {
         &self.ty
     }
     
-    /// The document id for this item.
+    /** The document id for this item. */
     pub fn id(&self) -> &TId {
         &self.id
     }
 }
 
-/// A failed bulk response item.
+/** A failed bulk response item. */
 #[derive(Debug, Clone)]
 pub struct ErrorItem<TIndex = DefaultAllocatedField, TType = DefaultAllocatedField, TId = DefaultAllocatedField> {
     action: Action,
@@ -446,22 +459,22 @@ pub struct ErrorItem<TIndex = DefaultAllocatedField, TType = DefaultAllocatedFie
 }
 
 impl<TIndex, TType, TId> ErrorItem<TIndex, TType, TId> {
-    /// The bulk action for this item.
+    /** The bulk action for this item. */
     pub fn action(&self) -> Action {
         self.action
     }
 
-    /// The index for this item.
+    /** The index for this item. */
     pub fn index(&self) -> &TIndex {
         &self.index
     }
     
-    /// The document type for this item.
+    /** The document type for this item. */
     pub fn ty(&self) -> &TType {
         &self.ty
     }
     
-    /// The document id for this item.
+    /** The document id for this item. */
     pub fn id(&self) -> &TId {
         &self.id
     }
@@ -491,7 +504,7 @@ impl<TIndex, TType, TId> Error for ErrorItem<TIndex, TType, TId>
     }
 }
 
-/// The bulk action being performed.
+/** The bulk action being performed. */
 #[derive(Deserialize, Debug, Clone, Copy)]
 pub enum Action {
     #[serde(rename = "index")]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,18 +1,22 @@
-//! Response types for a standard command.
+/*!
+Response types for a standard command.
+*/
 
 use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
-/// A standard command acknowledgement response.
+/** A standard command acknowledgement response. */
 #[derive(Deserialize, Debug, Clone)]
 pub struct CommandResponse {
     acknowledged: bool
 }
 
 impl CommandResponse {
-    /// Whether or not the request was acknowledged.
-    /// 
-    /// This doesn't necessarily mean the request has been fully processed.
+    /** 
+    Whether or not the request was acknowledged.
+    
+    This doesn't necessarily mean the request has been fully processed.
+    */
     pub fn acknowledged(&self) -> bool {
         self.acknowledged
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
-/// A default type for allocated fields in responses.
+/** A default type for allocated fields in responses. */
 pub(crate) type DefaultAllocatedField = String;
 
-/// Returned hits metadata.
+/** Returned hits metadata. */
 #[derive(Deserialize, Debug, Clone, Copy)]
 pub struct Shards {
     total: u32,
@@ -10,17 +10,17 @@ pub struct Shards {
 }
 
 impl Shards {
-    /// The total number of shards that participated in this request.
+    /** The total number of shards that participated in this request. */
     pub fn total(&self) -> u32 {
         self.total
     }
 
-    /// The total number of shards that successfully processed the request.
+    /** The total number of shards that successfully processed the request. */
     pub fn successful(&self) -> u32 {
         self.successful
     }
 
-    /// The total number of shards that failed to process the request.
+    /** The total number of shards that failed to process the request. */
     pub fn failed(&self) -> u32 {
         self.failed
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,20 @@
-//! Error types from Elasticsearch
+/*!
+Error types from Elasticsearch
+*/
 
 use serde::{Deserialize, Deserializer};
 use serde_json::{Map, Value, Error as JsonError};
 use std::io::Error as IoError;
 
 quick_error! {
-    /// An error parsing a response stream.
+    /** An error parsing a response stream. */
     #[derive(Debug)]
     pub enum ParseResponseError {
-        /// The response contains invalid json.
+        /** The response contains invalid json. */
         Json(err: JsonError) {
             from()
         }
-        /// The response caused an io error while buffering.
+        /** The response caused an io error while buffering. */
         Io(err: IoError) {
             from()
         }
@@ -20,14 +22,14 @@ quick_error! {
 }
 
 quick_error! {
-    /// An error parsing a REST API response to a success value.
+    /** An error parsing a REST API response to a success value. */
     #[derive(Debug)]
     pub enum ResponseError {
-        /// A REST API error from Elasticsearch.
+        /** A REST API error from Elasticsearch. */
         Api(err: ApiError) {
             from()
         }
-        /// An error parsing a response body.
+        /** An error parsing a response body. */
         Parse(err: ParseResponseError) {
             from()
         }
@@ -35,7 +37,7 @@ quick_error! {
 }
 
 quick_error! {
-    /// A REST API error response.
+    /** A REST API error response. */
     #[derive(Debug, PartialEq)]
     pub enum ApiError {
         IndexNotFound { index: String } {

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,11 +1,13 @@
-//! Response types for a [get document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html).
+/*!
+Response types for a [get document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html).
+*/
 
 use serde::de::DeserializeOwned;
 
 use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
-/// Response for a [get document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html).
+/** Response for a [get document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html). */
 #[derive(Deserialize, Debug)]
 pub struct GetResponse<T> {
     #[serde(rename = "_index")]
@@ -24,37 +26,37 @@ pub struct GetResponse<T> {
 }
 
 impl<T> GetResponse<T> {
-    /// Get a reference to the source document.
+    /** Get a reference to the source document. */
     pub fn document(&self) -> Option<&T> {
         self.source.as_ref()
     }
 
-    /// Convert the response into the source document.
+    /** Convert the response into the source document. */
     pub fn into_document(self) -> Option<T> {
         self.source
     }
 
-    /// Whether or not a matching document was found.
+    /** Whether or not a matching document was found. */
     pub fn found(&self) -> bool {
         self.found
     }
 
-    /// The index for the document.
+    /** The index for the document. */
     pub fn index(&self) -> &str {
         &self.index
     }
 
-    /// The type of the document.
+    /** The type of the document. */
     pub fn ty(&self) -> &str {
         &self.ty
     }
 
-    /// The id of the document.
+    /** The id of the document. */
     pub fn id(&self) -> &str {
         &self.id
     }
 
-    /// The version of the document.
+    /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,10 +1,12 @@
-//! Response types for an [index document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+/*!
+Response types for an [index document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+*/
 
 use common::Shards;
 use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
-/// Response for an [index document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+/** Response for an [index document request](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html). */
 #[derive(Deserialize, Debug)]
 pub struct IndexResponse {
     #[serde(rename = "_index")]
@@ -21,32 +23,32 @@ pub struct IndexResponse {
 }
 
 impl IndexResponse {
-    /// Shards metadata for the request.
+    /** Shards metadata for the request. */
     pub fn shards(&self) -> &Shards {
         &self.shards
     }
 
-    /// Whether or not a matching document was created.
+    /** Whether or not a matching document was created. */
     pub fn created(&self) -> bool {
         self.created
     }
 
-    /// The index for the document.
+    /** The index for the document. */
     pub fn index(&self) -> &str {
         &self.index
     }
 
-    /// The type of the document.
+    /** The type of the document. */
     pub fn ty(&self) -> &str {
         &self.ty
     }
 
-    /// The id of the document.
+    /** The id of the document. */
     pub fn id(&self) -> &str {
         &self.id
     }
 
-    /// The version of the document.
+    /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,127 +1,129 @@
-//! Elasticsearch Response Iterators
-//!
-//! A crate to handle parsing and handling Elasticsearch search results which provides
-//! convenient iterators to step through the results returned. It is designed to work
-//! with [`elastic-reqwest`][elastic-reqwest].
-//! It also re-exports `serde_json::Value` for convenient anonymous json objects.
-//! 
-//! This crate provides parsers that can be used to convert a http response into a concrete
-//! type or an API error.
-//!
-//! ## Usage
-//! 
-//! This crate is on [crates.io][crates-io].
-//! Add `elastic_responses` to your `Cargo.toml`:
-//! 
-//! ```text
-//! [dependencies]
-//! elastic_responses = "*"
-//! ```
-//! 
-//! Use the [`parse`][parse] function to deserialise a http response to a `Result<T, ApiError>` for some
-//! concrete response type `T`.
-//! 
-//! # Examples
-//!
-//! Run a [Query DSL][query-dsl] query, then iterate through the results:
-//!
-//! ```no_run
-//! # extern crate elastic_responses;
-//! # use elastic_responses::*;
-//! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-//! # fn main() {
-//! // Send a search request and read as a response
-//! let (response_status, response_body) = do_request();
-//! 
-//! // Parse body to JSON as an elastic_responses::SearchResponse object
-//! // If the response is an API error then it'll be parsed into a friendly Rust error
-//! let response = parse::<SearchResponse<Value>>().from_slice(response_status, response_body).unwrap();
-//!
-//! // Iterate over hits. Could also use `documents`
-//! for hit in response.hits() {
-//!     let score = hit.score().unwrap_or(f32::default());
-//!     let doc = hit.document();
-//!     
-//!     println!("score: {}", score);
-//!     println!("doc: {:?}", doc);
-//! }
-//!
-//! // Agregations are flattened into individual stats metrics
-//! for agg in response.aggs() {
-//!     let min_ack_pkts = agg["min_ack_pkts_sent"].as_u64().unwrap();
-//!     let max_ack_pkts = agg["max_ack_pkts_sent"].as_u64().unwrap();
-//!     
-//!     println!("min: {}, max: {}", min_ack_pkts, max_ack_pkts);
-//! }
-//! # }
-//! ```
-//! 
-//! Any type that implements `Deserialize` can be used as the document type in the search response:
-//! 
-//! ```no_run
-//! # #[macro_use] extern crate serde_derive;
-//! # extern crate serde;
-//! # extern crate elastic_responses;
-//! # use elastic_responses::*;
-//! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-//! # fn main() {
-//! #[derive(Deserialize)]
-//! struct MyDocument {
-//!     title: String,
-//!     description: String
-//! }
-//! 
-//! let (response_status, response_body) = do_request();
-//! 
-//! let response = parse::<SearchResponse<MyDocument>>().from_slice(response_status, response_body).unwrap();
-//!
-//! for doc in response.documents() {
-//!     println!("title: {}", doc.title);
-//!     println!("description: {}", doc.description);
-//! }
-//! # }
-//! ```
-//! 
-//! Run a [Get Document][get-document] request, and handle cases where the document wasn't found or the index doesn't exist:
-//! 
-//! ```no_run
-//! # extern crate serde_json;
-//! # extern crate elastic_responses;
-//! # use serde_json::Value;
-//! # use elastic_responses::*;
-//! # use elastic_responses::error::*;
-//! # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-//! # fn main() {
-//! // Send a document get request and read as a response
-//! let (response_status, response_body) = do_request();
-//!
-//! let response = parse::<GetResponse<Value>>().from_slice(response_status, response_body);
-//! 
-//! match response.map(|res| res.into_document()) {
-//!     Ok(Some(doc)) => {
-//!         // The document was found
-//!     }
-//!     Ok(None) => {
-//!         // The document was not found
-//!     }
-//!     Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
-//!         // The index doesn't exist
-//!     }
-//!     _ => {
-//!         // Some other error
-//!     }
-//! }
-//! # }
-//! ```
-//! 
-//! As with `SearchResponse`, any type that implements `Deserialize` can be used as the generic document type
-//! in a `GetResponse`.
-//! 
-//! [elastic-reqwest]: https://github.com/elastic-rs/elastic-reqwest/
-//! [crates-io]: https://crates.io/crates/elastic_responses
-//! [query-dsl]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html
-//! [get-document]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
-//! [parse]: parsing/fn.parse.html
+/*!
+Elasticsearch Response Iterators
+
+A crate to handle parsing and handling Elasticsearch search results which provides
+convenient iterators to step through the results returned. It is designed to work
+with [`elastic-reqwest`][elastic-reqwest].
+It also re-exports `serde_json::Value` for convenient anonymous json objects.
+
+This crate provides parsers that can be used to convert a http response into a concrete
+type or an API error.
+
+## Usage
+
+This crate is on [crates.io][crates-io].
+Add `elastic_responses` to your `Cargo.toml`:
+
+```text
+[dependencies]
+elastic_responses = "*"
+```
+
+Use the [`parse`][parse] function to deserialise a http response to a `Result<T, ApiError>` for some
+concrete response type `T`.
+
+# Examples
+
+Run a [Query DSL][query-dsl] query, then iterate through the results:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+// Send a search request and read as a response
+let (response_status, response_body) = do_request();
+
+// Parse body to JSON as an elastic_responses::SearchResponse object
+// If the response is an API error then it'll be parsed into a friendly Rust error
+let response = parse::<SearchResponse<Value>>().from_slice(response_status, response_body).unwrap();
+
+// Iterate over hits. Could also use `documents`
+for hit in response.hits() {
+    let score = hit.score().unwrap_or(f32::default());
+    let doc = hit.document();
+    
+    println!("score: {}", score);
+    println!("doc: {:?}", doc);
+}
+
+// Agregations are flattened into individual stats metrics
+for agg in response.aggs() {
+    let min_ack_pkts = agg["min_ack_pkts_sent"].as_u64().unwrap();
+    let max_ack_pkts = agg["max_ack_pkts_sent"].as_u64().unwrap();
+    
+    println!("min: {}, max: {}", min_ack_pkts, max_ack_pkts);
+}
+# }
+```
+
+Any type that implements `Deserialize` can be used as the document type in the search response:
+
+```no_run
+# #[macro_use] extern crate serde_derive;
+# extern crate serde;
+# extern crate elastic_responses;
+# use elastic_responses::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+#[derive(Deserialize)]
+struct MyDocument {
+    title: String,
+    description: String
+}
+
+let (response_status, response_body) = do_request();
+
+let response = parse::<SearchResponse<MyDocument>>().from_slice(response_status, response_body).unwrap();
+
+for doc in response.documents() {
+    println!("title: {}", doc.title);
+    println!("description: {}", doc.description);
+}
+# }
+```
+
+Run a [Get Document][get-document] request, and handle cases where the document wasn't found or the index doesn't exist:
+
+```no_run
+# extern crate serde_json;
+# extern crate elastic_responses;
+# use serde_json::Value;
+# use elastic_responses::*;
+# use elastic_responses::error::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+// Send a document get request and read as a response
+let (response_status, response_body) = do_request();
+
+let response = parse::<GetResponse<Value>>().from_slice(response_status, response_body);
+
+match response.map(|res| res.into_document()) {
+    Ok(Some(doc)) => {
+        // The document was found
+    }
+    Ok(None) => {
+        // The document was not found
+    }
+    Err(ResponseError::Api(ApiError::IndexNotFound { index })) => {
+        // The index doesn't exist
+    }
+    _ => {
+        // Some other error
+    }
+}
+# }
+```
+
+As with `SearchResponse`, any type that implements `Deserialize` can be used as the generic document type
+in a `GetResponse`.
+
+[elastic-reqwest]: https://github.com/elastic-rs/elastic-reqwest/
+[crates-io]: https://crates.io/crates/elastic_responses
+[query-dsl]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html
+[get-document]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
+[parse]: parsing/fn.parse.html
+*/
 
 #[macro_use]
 extern crate log;
@@ -159,5 +161,5 @@ pub use self::index::*;
 
 pub use self::parsing::parse;
 
-/// Re-export of `serde_json::Value` for convenience.
+/** Re-export of `serde_json::Value` for convenience. */
 pub use serde_json::Value;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -300,7 +300,7 @@ impl<B> MaybeOkResponse<B> where B: ResponseBody
 pub struct Unbuffered<B>(B);
 
 impl<B: ResponseBody> Unbuffered<B> {
-    Buffer the response body to a json value and return a new buffered representation.
+    /** Buffer the response body to a json value and return a new buffered representation. */
     pub fn body(self) -> Result<(Value, Buffered<B>), ParseResponseError> {
         self.0.body().map(|(value, body)| (value, Buffered(body)))
     }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,4 +1,6 @@
-//! Response type parsing.
+/*! 
+Response type parsing.
+*/
 
 use std::marker::PhantomData;
 use std::io::{Cursor, Read};
@@ -7,70 +9,72 @@ use serde_json::{self, Value};
 
 use error::*;
 
-/// A parser that separates taking a response type from the readable body type.
+/** A parser that separates taking a response type from the readable body type. */
 pub struct Parse<T> {
     _marker: PhantomData<T>,
 }
 
-/// Try parse a http response into a concrete type.
-/// 
-/// Parsing is split between two calls:
-/// 
-/// - `parse` where you can specify the response type
-/// - `from_slice`/`from_reader` wher you can specify the kind of body to read from
-/// 
-/// The reason for splitting the functions is so we can infer the types of arguments to `from_slice` and `from_reader`,
-/// but provide the concrete response type in cases it can't be inferred.
-/// 
-/// # Examples
-/// 
-/// Provide an explicit response type in the `parse` function:
-/// 
-/// ```no_run
-/// # extern crate serde_json;
-/// # extern crate elastic_responses;
-/// # use serde_json::*;
-/// # use elastic_responses::*;
-/// # use elastic_responses::error::*;
-/// # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-/// # fn main() {
-/// # let (response_status, response_body) = do_request();
-/// let get_response = parse::<GetResponse<Value>>().from_slice(response_status, response_body);
-/// # }
-/// ```
-/// 
-/// Provide an explicit response type on the result ident:
-/// 
-/// ```no_run
-/// # extern crate serde_json;
-/// # extern crate elastic_responses;
-/// # use serde_json::Value;
-/// # use elastic_responses::*;
-/// # use elastic_responses::error::*;
-/// # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-/// # fn main() {
-/// # let (response_status, response_body) = do_request();
-/// let get_response: Result<GetResponse<Value>, ResponseError> = parse().from_slice(response_status, response_body);
-/// # }
-/// ```
-/// 
-/// If Rust can infer the concrete response type then you can avoid specifying it at all:
-/// 
-/// ```no_run
-/// # extern crate serde_json;
-/// # extern crate elastic_responses;
-/// # use serde_json::Value;
-/// # use elastic_responses::*;
-/// # use elastic_responses::error::*;
-/// # fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
-/// # fn main() {
-/// # fn parse_response() -> Result<GetResponse<Value>, ResponseError> {
-/// # let (response_status, response_body) = do_request();
-/// let get_response = parse().from_slice(response_status, response_body);
-/// # get_response
-/// # }
-/// # }
-/// ```
+/* 
+Try parse a http response into a concrete type.
+
+Parsing is split between two calls:
+
+- `parse` where you can specify the response type
+- `from_slice`/`from_reader` wher you can specify the kind of body to read from
+
+The reason for splitting the functions is so we can infer the types of arguments to `from_slice` and `from_reader`,
+but provide the concrete response type in cases it can't be inferred.
+
+# Examples
+
+Provide an explicit response type in the `parse` function:
+
+```no_run
+# extern crate serde_json;
+# extern crate elastic_responses;
+# use serde_json::*;
+# use elastic_responses::*;
+# use elastic_responses::error::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+# let (response_status, response_body) = do_request();
+let get_response = parse::<GetResponse<Value>>().from_slice(response_status, response_body);
+# }
+```
+
+Provide an explicit response type on the result ident:
+
+```no_run
+# extern crate serde_json;
+# extern crate elastic_responses;
+# use serde_json::Value;
+# use elastic_responses::*;
+# use elastic_responses::error::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+# let (response_status, response_body) = do_request();
+let get_response: Result<GetResponse<Value>, ResponseError> = parse().from_slice(response_status, response_body);
+# }
+```
+
+If Rust can infer the concrete response type then you can avoid specifying it at all:
+
+```no_run
+# extern crate serde_json;
+# extern crate elastic_responses;
+# use serde_json::Value;
+# use elastic_responses::*;
+# use elastic_responses::error::*;
+# fn do_request() -> (u16, Vec<u8>) { unimplemented!() }
+# fn main() {
+# fn parse_response() -> Result<GetResponse<Value>, ResponseError> {
+# let (response_status, response_body) = do_request();
+let get_response = parse().from_slice(response_status, response_body);
+# get_response
+# }
+# }
+```
+*/
 pub fn parse<T: IsOk + DeserializeOwned>() -> Parse<T> {
     Parse {
         _marker: PhantomData,
@@ -78,12 +82,12 @@ pub fn parse<T: IsOk + DeserializeOwned>() -> Parse<T> {
 }
 
 impl<T: IsOk + DeserializeOwned> Parse<T> {
-    /// Try parse a contiguous slice of bytes into a concrete response.
+    /** Try parse a contiguous slice of bytes into a concrete response. */
     pub fn from_slice<B: AsRef<[u8]>, H: Into<HttpResponseHead>>(self, head: H, body: B) -> Result<T, ResponseError> {
         from_body(head.into(), SliceBody(body))
     }
 
-    /// Try parse an arbitrary reader into a concrete response.
+    /** Try parse an arbitrary reader into a concrete response. */
     pub fn from_reader<B: Read, H: Into<HttpResponseHead>>(self, head: H, body: B) -> Result<T, ResponseError> {
         from_body(head.into(), ReadBody(body))
     }
@@ -104,13 +108,13 @@ fn from_body<B: ResponseBody, T: IsOk + DeserializeOwned>(head: HttpResponseHead
     }
 }
 
-/// The non-body component of the HTTP response.
+/** The non-body component of the HTTP response. */
 pub struct HttpResponseHead {
     code: u16,
 }
 
 impl HttpResponseHead {
-    /// Get the status code.
+    /** Get the status code. */
     pub fn status(&self) -> u16 {
         self.code
     }
@@ -124,19 +128,19 @@ impl From<u16> for HttpResponseHead {
     }
 }
 
-/// A http response body that can be buffered into a json value.
+/** A http response body that can be buffered into a json value. */
 pub trait ResponseBody where Self: Sized
 {
-    /// The type of a buffered response body.
+    /** The type of a buffered response body. */
     type Buffered: ResponseBody;
 
-    /// Buffer the response body to a json value and return a new buffered representation.
+    /** Buffer the response body to a json value and return a new buffered representation. */
     fn body(self) -> Result<(Value, Self::Buffered), ParseResponseError>;
 
-    /// Parse the body as a success result.
+    /** Parse the body as a success result. */
     fn parse_ok<T: DeserializeOwned>(self) -> Result<T, ParseResponseError>;
 
-    /// Parse the body as an API error.
+    /** Parse the body as an API error. */
     fn parse_err(self) -> Result<ApiError, ParseResponseError>;
 }
 
@@ -185,61 +189,63 @@ impl<B: AsRef<[u8]>> ResponseBody for SliceBody<B> {
     }
 }
 
-/// Convert a response message into a either a success
-/// or failure result.
-/// 
-/// This is the main trait that drives response parsing by inspecting the http status and potentially
-/// buffering the response to determine whether or not it represents a successful operation.
-/// This trait doesn't do the actual deserialisation, it just passes on a `MaybeOkResponse`.
-/// 
-/// Some endpoints may not map success or error responses directly to a status code.
-/// In this case, the `Unbuffered` body can be buffered into an anonymous json object and inspected
-/// for an error node.
-/// The `Unbuffered` type takes care of response bodies that can only be buffered once.
-/// 
-/// Any type that implements `IsOk` can be deserialised by `parse`.
-/// Implementations should behave in the following way:
-/// 
-/// - If the response is successful, this trait should return `Ok(MaybeOkResponse::ok)`.
-/// - If the response is an error, this trait should return `Ok(MaybeOkResponse::err)`.
-/// - If the response isn't recognised or is otherwise invalid, this trait should return `Err`.
-/// 
-/// # Examples
-/// 
-/// Implement `IsOk` for a custom response type, where a http `404` might still contain a valid response:
-/// 
-/// ```
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde;
-/// # extern crate elastic_responses;
-/// # use elastic_responses::parsing::*;
-/// # use elastic_responses::error::*;
-/// # fn main() {}
-/// # #[derive(Deserialize)]
-/// # struct MyResponse;
-/// impl IsOk for MyResponse {
-///     fn is_ok<B: ResponseBody>(head: HttpResponseHead, unbuffered: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
-///         match head.status() {
-///             200...299 => Ok(MaybeOkResponse::ok(unbuffered)),
-///             404 => {
-///                 // If we get a 404, it could be an IndexNotFound error or ok
-///                 // Check if the response contains a root 'error' node
-///                 let (body, buffered) = unbuffered.body()?;
-/// 
-///                 let is_ok = body.as_object()
-///                     .and_then(|body| body.get("error"))
-///                     .is_none();
-/// 
-///                 Ok(MaybeOkResponse::new(is_ok, buffered))
-///             }
-///             _ => Ok(MaybeOkResponse::err(unbuffered)),
-///         }
-///     }
-/// }
-/// ```
+/**
+Convert a response message into a either a success
+or failure result.
+
+This is the main trait that drives response parsing by inspecting the http status and potentially
+buffering the response to determine whether or not it represents a successful operation.
+This trait doesn't do the actual deserialisation, it just passes on a `MaybeOkResponse`.
+
+Some endpoints may not map success or error responses directly to a status code.
+In this case, the `Unbuffered` body can be buffered into an anonymous json object and inspected
+for an error node.
+The `Unbuffered` type takes care of response bodies that can only be buffered once.
+
+Any type that implements `IsOk` can be deserialised by `parse`.
+Implementations should behave in the following way:
+
+- If the response is successful, this trait should return `Ok(MaybeOkResponse::ok)`.
+- If the response is an error, this trait should return `Ok(MaybeOkResponse::err)`.
+- If the response isn't recognised or is otherwise invalid, this trait should return `Err`.
+
+# Examples
+
+Implement `IsOk` for a custom response type, where a http `404` might still contain a valid response:
+
+```
+# #[macro_use] extern crate serde_derive;
+# extern crate serde;
+# extern crate elastic_responses;
+# use elastic_responses::parsing::*;
+# use elastic_responses::error::*;
+# fn main() {}
+# #[derive(Deserialize)]
+# struct MyResponse;
+impl IsOk for MyResponse {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead, unbuffered: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+        match head.status() {
+            200...299 => Ok(MaybeOkResponse::ok(unbuffered)),
+            404 => {
+                // If we get a 404, it could be an IndexNotFound error or ok
+                // Check if the response contains a root 'error' node
+                let (body, buffered) = unbuffered.body()?;
+
+                let is_ok = body.as_object()
+                    .and_then(|body| body.get("error"))
+                    .is_none();
+
+                Ok(MaybeOkResponse::new(is_ok, buffered))
+            }
+            _ => Ok(MaybeOkResponse::err(unbuffered)),
+        }
+    }
+}
+```
+*/
 pub trait IsOk
 {
-    /// Inspect the http response to determine whether or not it succeeded.
+    /** Inspect the http response to determine whether or not it succeeded. */
     fn is_ok<B: ResponseBody>(head: HttpResponseHead, unbuffered: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError>;
 }
 
@@ -252,7 +258,7 @@ impl IsOk for Value {
     }
 }
 
-/// A response that might be successful or an `ApiError`.
+/** A response that might be successful or an `ApiError`. */
 pub struct MaybeOkResponse<B> 
     where B: ResponseBody
 {
@@ -262,8 +268,10 @@ pub struct MaybeOkResponse<B>
 
 impl<B> MaybeOkResponse<B> where B: ResponseBody
 {
-    /// Create a new response that indicates where or not the
-    /// body is successful or an `ApiError`.
+    /** 
+    Create a new response that indicates where or not the
+    body is successful or an `ApiError`.
+    */
     pub fn new<I>(ok: bool, res: I) -> Self
         where I: Into<MaybeBufferedResponse<B>>
     {
@@ -273,14 +281,14 @@ impl<B> MaybeOkResponse<B> where B: ResponseBody
         }
     }
 
-    /// Create a response where the body is successful.
+    /** Create a response where the body is successful. */
     pub fn ok<I>(res: I) -> Self
         where I: Into<MaybeBufferedResponse<B>>
     {
         Self::new(true, res)
     }
 
-    /// Create a resposne where the body is an error.
+    /** Create a resposne where the body is an error. */
     pub fn err<I>(res: I) -> Self
         where I: Into<MaybeBufferedResponse<B>>
     {
@@ -288,23 +296,25 @@ impl<B> MaybeOkResponse<B> where B: ResponseBody
     }
 }
 
-/// A response body that hasn't been buffered yet.
+/** A response body that hasn't been buffered yet. */
 pub struct Unbuffered<B>(B);
 
 impl<B: ResponseBody> Unbuffered<B> {
-    /// Buffer the response body to a json value and return a new buffered representation.
+    Buffer the response body to a json value and return a new buffered representation.
     pub fn body(self) -> Result<(Value, Buffered<B>), ParseResponseError> {
         self.0.body().map(|(value, body)| (value, Buffered(body)))
     }
 }
 
-/// A response body that has been buffered.
+/** A response body that has been buffered. */
 pub struct Buffered<B: ResponseBody>(B::Buffered);
 
-/// A response body that may or may not have been buffered.
-///
-/// This type makes it possible to inspect the response body for
-/// an error type before passing it along to be deserialised properly.
+/** 
+A response body that may or may not have been buffered.
+
+This type makes it possible to inspect the response body for
+an error type before passing it along to be deserialised properly.
+*/
 pub enum MaybeBufferedResponse<B>
     where B: ResponseBody
 {

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,9 +1,11 @@
-//! Response types for a cluster ping request.
+/*! 
+Response types for a cluster ping request.
+*/
 
 use parsing::{IsOk, HttpResponseHead, ResponseBody, Unbuffered, MaybeOkResponse};
 use error::*;
 
-/// Response for a cluster ping request.
+/** Response for a cluster ping request. */
 #[derive(Deserialize, Debug)]
 pub struct PingResponse {
     name: String,
@@ -23,44 +25,44 @@ pub struct ClusterVersion {
 }
 
 impl PingResponse {
-    /// The name of the pinged node.
+    /** The name of the pinged node. */
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// The name of the cluster the pinged node belongs to.
+    /** The name of the cluster the pinged node belongs to. */
     pub fn cluster_name(&self) -> &str {
         &self.cluster_name
     }
 
-    /// The Elasticsearch version metadata.
+    /** The Elasticsearch version metadata. */
     pub fn version(&self) -> &ClusterVersion {
         &self.version
     }
 }
 
 impl ClusterVersion {
-    /// The builder number.
+    /** The builder number. */
     pub fn number(&self) -> &str {
         &self.number
     }
 
-    /// The build hash.
+    /** The build hash. */
     pub fn hash(&self) -> &str {
         &self.build_hash
     }
 
-    // The build date.
+    /** The build date. */
     pub fn date(&self) -> &str {
         &self.build_date
     }
 
-    /// Whether or not the build is a snapshot.
+    /** Whether or not the build is a snapshot. */
     pub fn snapshot(&self) -> bool {
         self.build_snapshot
     }
 
-    /// The underlying Lucene version.
+    /** The underlying Lucene version. */
     pub fn lucene_version(&self) -> &str {
         &self.lucene_version
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,6 @@
-//! Response types for a [search request](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html).
+/*! 
+Response types for a [search request](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html).
+*/
 
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
@@ -12,42 +14,44 @@ use std::collections::BTreeMap;
 use std::slice::Iter;
 use std::vec::IntoIter;
 
-/// Response for a [search request][search-req].
-/// 
-/// This is the main `struct` of the crate, provides access to the `hits` and `aggs` iterators.
-/// 
-/// # Aggregations
-/// 
-/// Aggregations currently have the following limitations:
-/// 
-/// - Only metric aggregations nested in buckets are supported
-/// - Only [Simple Metric Aggregations][metric-aggs] like `avg`, `min`, `max`, `sum` and [Stats Aggregations][stats-aggs] are supported
-/// 
-/// # Examples
-/// 
-/// Iterate over the hits in a search response:
-/// 
-/// ```no_run
-/// # extern crate elastic_responses;
-/// # use elastic_responses::{SearchResponse, Value};
-/// # fn do_request() -> SearchResponse<Value> { unimplemented!() }
-/// # fn main() {
-/// let response: SearchResponse<Value> = do_request();
-///
-/// // Iterate over hits. Could also use `documents`
-/// for hit in response.hits() {
-///     let score = hit.score().unwrap_or(f32::default());
-///     let doc = hit.document();
-///     
-///     println!("score: {}", score);
-///     println!("doc: {:?}", doc);
-/// }
-/// # }
-/// ```
-/// 
-/// [search-req]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
-/// [metric-aggs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics.html
-/// [stats-aggs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
+/** 
+Response for a [search request][search-req].
+
+This is the main `struct` of the crate, provides access to the `hits` and `aggs` iterators.
+
+# Aggregations
+
+Aggregations currently have the following limitations:
+
+- Only metric aggregations nested in buckets are supported
+- Only [Simple Metric Aggregations][metric-aggs] like `avg`, `min`, `max`, `sum` and [Stats Aggregations][stats-aggs] are supported
+
+# Examples
+
+Iterate over the hits in a search response:
+
+```no_run
+# extern crate elastic_responses;
+# use elastic_responses::{SearchResponse, Value};
+# fn do_request() -> SearchResponse<Value> { unimplemented!() }
+# fn main() {
+let response: SearchResponse<Value> = do_request();
+
+// Iterate over hits. Could also use `documents`
+for hit in response.hits() {
+    let score = hit.score().unwrap_or(f32::default());
+    let doc = hit.document();
+    
+    println!("score: {}", score);
+    println!("doc: {:?}", doc);
+}
+# }
+```
+
+[search-req]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
+[metric-aggs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics.html
+[stats-aggs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
+*/
 #[derive(Deserialize, Debug)]
 pub struct SearchResponse<T> {
     took: u64,
@@ -59,7 +63,7 @@ pub struct SearchResponse<T> {
     status: Option<u16>,
 }
 
-/// Struct to hold the search's Hits, serializable to type `T` or `serde_json::Value`
+/** Struct to hold the search's Hits, serializable to type `T` or `serde_json::Value`. */
 #[derive(Deserialize, Debug)]
 struct HitsWrapper<T> {
     total: u64,
@@ -69,62 +73,65 @@ struct HitsWrapper<T> {
 }
 
 impl<T> SearchResponse<T> {
-    /// Time in milliseconds it took for Elasticsearch to process the request.
+    /** Time in milliseconds it took for Elasticsearch to process the request. */
     pub fn took(&self) -> u64 {
         self.took
     }
 
-    /// Whether or not the request timed out before completing.
+    /** Whether or not the request timed out before completing. */
     pub fn timed_out(&self) -> bool {
         self.timed_out
     }
 
-    /// Shards metadata for the request.
+    /** Shards metadata for the request. */
     pub fn shards(&self) -> &Shards {
         &self.shards
     }
 
-    /// A http status associated with the response.
+    /** A http status associated with the response. */
     pub fn status(&self) -> Option<u16> {
         self.status.clone()
     }
 
-    /// The total number of documents that matched the search query.
+    /** The total number of documents that matched the search query. */
     pub fn total(&self) -> u64 {
         self.hits.total
     }
 
-    /// The max score for documents that matched the search query.
+    /** The max score for documents that matched the search query. */
     pub fn max_score(&self) -> Option<f32> {
         self.hits.max_score.clone()
     }
 
-    /// Iterate over the hits matched by the search query.
+    /** Iterate over the hits matched by the search query. */
     pub fn hits(&self) -> Hits<T> {
         Hits::new(&self.hits)
     }
 
-    /// Convert the response into an iterator that consumes the hits.
+    /** Convert the response into an iterator that consumes the hits. */
     pub fn into_hits(self) -> IntoHits<T> {
         IntoHits::new(self.hits)
     }
 
-    /// Iterate over the documents matched by the search query.
-    /// 
-    /// This iterator emits just the `_source` field for the returned hits.
+    /** 
+    Iterate over the documents matched by the search query.
+    
+    This iterator emits just the `_source` field for the returned hits.
+    */
     pub fn documents(&self) -> Documents<T> {
         Documents::new(&self.hits)
     }
 
-    /// Convert the response into an iterator that consumes the documents.
+    /** Convert the response into an iterator that consumes the documents. */
     pub fn into_documents(self) -> IntoDocuments<T> {
         IntoDocuments::new(self.hits)
     }
 
-    /// Iterate over the aggregations in the response.
-    ///
-    /// This Iterator transforms the tree-like JSON object into a row/table
-    /// based format for use with standard iterator adaptors.
+    /** 
+    Iterate over the aggregations in the response.
+    
+    This Iterator transforms the tree-like JSON object into a row/table based format for use with standard iterator adaptors.
+    */
     pub fn aggs(&self) -> Aggs {
         Aggs::new(self.aggregations.as_ref())
     }
@@ -139,7 +146,7 @@ impl<T: DeserializeOwned> IsOk for SearchResponse<T> {
     }
 }
 
-/// A borrowing iterator over search query hits.
+/** A borrowing iterator over search query hits. */
 pub struct Hits<'a, T: 'a> {
     inner: Iter<'a, Hit<T>>,
 }
@@ -160,7 +167,7 @@ impl<'a, T: 'a> Iterator for Hits<'a, T> {
     }
 }
 
-/// A consuminig iterator over search query hits.
+/** A consuminig iterator over search query hits. */
 pub struct IntoHits<T> {
     inner: IntoIter<Hit<T>>,
 }
@@ -181,7 +188,7 @@ impl<T> Iterator for IntoHits<T> {
     }
 }
 
-/// A borrowing iterator over the source documents in search query hits.
+/** A borrowing iterator over the source documents in search query hits. */
 pub struct Documents<'a, T: 'a> {
     inner: Iter<'a, Hit<T>>,
 }
@@ -202,7 +209,7 @@ impl<'a, T: 'a> Iterator for Documents<'a, T> {
     }
 }
 
-/// A consuming iterator over the source documents in search query hits.
+/** A consuming iterator over the source documents in search query hits. */
 pub struct IntoDocuments<T> {
     inner: IntoIter<Hit<T>>,
 }
@@ -223,7 +230,7 @@ impl<T> Iterator for IntoDocuments<T> {
     }
 }
 
-/// Full metadata and source for a single hit.
+/** Full metadata and source for a single hit. */
 #[derive(Deserialize, Debug)]
 pub struct Hit<T> {
     #[serde(rename = "_index")]
@@ -241,43 +248,44 @@ pub struct Hit<T> {
 }
 
 impl<T> Hit<T> {
-    /// Get a reference to the source document.
+    /** Get a reference to the source document. */
     pub fn document(&self) -> Option<&T> {
         self.source.as_ref()
     }
 
-    /// Convert the hit into the source document.
+    /** Convert the hit into the source document. */
     pub fn into_document(self) -> Option<T> {
         self.source
     }
 
-    /// The index for the hit.
+    /** The index for the hit. */
     pub fn index(&self) -> &str {
         &self.index
     }
 
-    /// The type of the hit.
+    /** The type of the hit. */
     pub fn ty(&self) -> &str {
         &self.ty
     }
 
-    /// The version of the hit.
+    /** The version of the hit. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
     }
 
-    /// The score of the hit.
+    /** The score of the hit. */
     pub fn score(&self) -> Option<f32> {
         self.score.clone()
     }
 }
 
-/// Type Struct to hold a generic `serde_json::Value` tree of the aggregation results.
+/** Type Struct to hold a generic `serde_json::Value` tree of the aggregation results. */
 #[derive(Deserialize, Debug)]
 struct AggsWrapper(Value);
 
-/// Aggregator that traverses the results from Elasticsearch's aggregations and returns a result
-/// row by row in a table-styled fashion.
+/** 
+Aggregator that traverses the results from Elasticsearch's aggregations and returns a result row by row in a table-styled fashion.
+*/
 #[derive(Debug)]
 pub struct Aggs<'a> {
     current_row: Option<RowData<'a>>,


### PR DESCRIPTION
Use block doc comments instead of the `//! ` or `/// ` form. I find the block kinds better to work with when you're expanding the docs.