### PR TITLE
Add index already exists variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,10 @@ quick_error! {
             description("index not found")
             display("index not found: '{}'", index)
         }
+        IndexAlreadyExists { index: String } {
+            description("index already exists")
+            display("index already exists: '{}'", index)
+        }
         Parsing { line: u64, col: u64, reason: String } {
             description("request parse error")
             display("request parse error: '{}' on line: {}, col: {}", reason, line, col)
@@ -57,6 +61,8 @@ quick_error! {
             description("error response from Elasticsearch")
             display("error response from Elasticsearch: {:?}", v)
         }
+        #[doc(hidden)]
+        __NonExhaustive {}
     }
 }
 
@@ -109,6 +115,11 @@ impl From<Map<String, Value>> for ApiError {
                 let index = error_key!(obj[index]: |v| v.as_str());
 
                 ApiError::IndexNotFound { index: index.into() }
+            }
+            "index_already_exists_exception" => {
+                let index = error_key!(obj[index]: |v| v.as_str());
+
+                ApiError::IndexAlreadyExists { index: index.into() }
             }
             "parsing_exception" => {
                 let line = error_key!(obj[line]: |v| v.as_u64());

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -20,11 +20,25 @@ fn success_parse_response() {
 #[test]
 fn error_parse_mapping() {
     let f = load_file("tests/samples/error_mapper_parsing.json");
-    let deserialized = parse::<IndexResponse>().from_reader(404, f).unwrap_err();
+    let deserialized = parse::<IndexResponse>().from_reader(400, f).unwrap_err();
 
     let valid = match deserialized {
         ResponseError::Api(ApiError::MapperParsing { ref reason })
         if reason == "failed to parse, document is empty" => true,
+        _ => false
+    };
+
+    assert!(valid);
+}
+
+#[test]
+fn error_parse_index_already_exists() {
+    let f = load_file("tests/samples/error_index_already_exists.json");
+    let deserialized = parse::<IndexResponse>().from_reader(400, f).unwrap_err();
+
+    let valid = match deserialized {
+        ResponseError::Api(ApiError::IndexAlreadyExists { ref index })
+        if index == "carrots" => true,
         _ => false
     };
 

--- a/tests/samples/error_index_already_exists.json
+++ b/tests/samples/error_index_already_exists.json
@@ -1,0 +1,17 @@
+{
+    "error": {
+        "root_cause": [
+            {
+                "type": "index_already_exists_exception",
+                "reason": "index [carrots/PhdlpbQbSYis7egyEAoGSw] already exists",
+                "index_uuid": "PhdlpbQbSYis7egyEAoGSw",
+                "index": "carrots"
+            }
+        ],
+        "type": "index_already_exists_exception",
+        "reason": "index [carrots/PhdlpbQbSYis7egyEAoGSw] already exists",
+        "index_uuid": "PhdlpbQbSYis7egyEAoGSw",
+        "index": "carrots"
+    },
+    "status": 400
+}

--- a/tests/samples/search_bank_sample.json
+++ b/tests/samples/search_bank_sample.json
@@ -1,0 +1,205 @@
+{
+  "took" : 3,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 20,
+    "successful" : 20,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 2008,
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "25",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 25,
+          "balance" : 40540,
+          "firstname" : "Virginia",
+          "lastname" : "Ayala",
+          "age" : 39,
+          "gender" : "F",
+          "address" : "171 Putnam Avenue",
+          "employer" : "Filodyne",
+          "email" : "virginiaayala@filodyne.com",
+          "city" : "Nicholson",
+          "state" : "PA"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "44",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 44,
+          "balance" : 34487,
+          "firstname" : "Aurelia",
+          "lastname" : "Harding",
+          "age" : 37,
+          "gender" : "M",
+          "address" : "502 Baycliff Terrace",
+          "employer" : "Orbalix",
+          "email" : "aureliaharding@orbalix.com",
+          "city" : "Yardville",
+          "state" : "DE"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "99",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 99,
+          "balance" : 47159,
+          "firstname" : "Ratliff",
+          "lastname" : "Heath",
+          "age" : 39,
+          "gender" : "F",
+          "address" : "806 Rockwell Place",
+          "employer" : "Zappix",
+          "email" : "ratliffheath@zappix.com",
+          "city" : "Shaft",
+          "state" : "ND"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "119",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 119,
+          "balance" : 49222,
+          "firstname" : "Laverne",
+          "lastname" : "Johnson",
+          "age" : 28,
+          "gender" : "F",
+          "address" : "302 Howard Place",
+          "employer" : "Senmei",
+          "email" : "lavernejohnson@senmei.com",
+          "city" : "Herlong",
+          "state" : "DC"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "126",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 126,
+          "balance" : 3607,
+          "firstname" : "Effie",
+          "lastname" : "Gates",
+          "age" : 39,
+          "gender" : "F",
+          "address" : "620 National Drive",
+          "employer" : "Digitalus",
+          "email" : "effiegates@digitalus.com",
+          "city" : "Blodgett",
+          "state" : "MD"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "145",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 145,
+          "balance" : 47406,
+          "firstname" : "Rowena",
+          "lastname" : "Wilkinson",
+          "age" : 32,
+          "gender" : "M",
+          "address" : "891 Elton Street",
+          "employer" : "Asimiline",
+          "email" : "rowenawilkinson@asimiline.com",
+          "city" : "Ripley",
+          "state" : "NH"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "183",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 183,
+          "balance" : 14223,
+          "firstname" : "Hudson",
+          "lastname" : "English",
+          "age" : 26,
+          "gender" : "F",
+          "address" : "823 Herkimer Place",
+          "employer" : "Xinware",
+          "email" : "hudsonenglish@xinware.com",
+          "city" : "Robbins",
+          "state" : "ND"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "190",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 190,
+          "balance" : 3150,
+          "firstname" : "Blake",
+          "lastname" : "Davidson",
+          "age" : 30,
+          "gender" : "F",
+          "address" : "636 Diamond Street",
+          "employer" : "Quantasis",
+          "email" : "blakedavidson@quantasis.com",
+          "city" : "Crumpler",
+          "state" : "KY"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "208",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 208,
+          "balance" : 40760,
+          "firstname" : "Garcia",
+          "lastname" : "Hess",
+          "age" : 26,
+          "gender" : "F",
+          "address" : "810 Nostrand Avenue",
+          "employer" : "Quiltigen",
+          "email" : "garciahess@quiltigen.com",
+          "city" : "Brooktrails",
+          "state" : "GA"
+        }
+      },
+      {
+        "_index" : "bulk-async",
+        "_type" : "bulk-ty",
+        "_id" : "222",
+        "_score" : 1.0,
+        "_source" : {
+          "account_number" : 222,
+          "balance" : 14764,
+          "firstname" : "Rachelle",
+          "lastname" : "Rice",
+          "age" : 36,
+          "gender" : "M",
+          "address" : "333 Narrows Avenue",
+          "employer" : "Enaut",
+          "email" : "rachellerice@enaut.com",
+          "city" : "Wright",
+          "state" : "AZ"
+        }
+      }
+    ]
+  }
+}

--- a/tests/search/mod.rs
+++ b/tests/search/mod.rs
@@ -65,6 +65,14 @@ fn success_parse_hits_no_score() {
 }
 
 #[test]
+fn success_parse_hits_bank_sample() {
+    let f = load_file("tests/samples/search_bank_sample.json");
+    let deserialized = parse::<SearchResponse<Value>>().from_reader(200, f).unwrap();
+
+    assert_eq!(deserialized.hits().into_iter().count(), 10);
+}
+
+#[test]
 fn success_aggs_when_not_present() {
     let f = load_file("tests/samples/search_hits_only.json");
     let deserialized = parse::<SearchResponse<Value>>().from_reader(200, f).unwrap();


### PR DESCRIPTION
As pointed out in https://github.com/elastic-rs/elastic/issues/218 it's currently not nice to recover from an `index_already_exists_exception`.

This PR adds an `IndexAlreadyExists` variant to `ApiError`, as well as a `__NonExhaustive` variant so we can change this enum in the future without requiring a breaking change.